### PR TITLE
Add typed connection settings and JSON loader integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ Examples:
 - Start dev server: `npm run dev`
 - Build web (dist/): `npm run build`
 
+## Connection configuration
+
+- Use the ⚙️ Settings button (or the cog in the data source panel) to open the connection drawer.
+- Defaults target `http://192.168.0.71` for the unified hKG MCP endpoint (`:49160`) and service-specific ports (Neo4j `:7474`, Qdrant `:6333`, PostgreSQL `:5432`, Ollama `:11434`).
+- Toggle between **Unified MCP** and **Per-service** modes. Per-service mode issues requests directly to the configured endpoints and supports basic auth/API keys.
+- Settings persist in browser/local storage; the reset button restores the 192.168.0.71 defaults.
+- Hybrid knowledge graph sync endpoints are not reachable in this sandbox; update the settings to point at a reachable MCP host when running on your network.
+
+## JSON knowledge graph uploads
+
+- Select **File Upload** in the Data Sources panel to ingest local JSON knowledge graphs.
+- The loader accepts either `{ knowledge_graph: { entities, relationships } }` or a top-level `{ entities, relationships }` object and annotates metadata with timestamp, filename, and file size.
+- Uploaded data is processed with the same typing pipeline used for live hKG responses, so downstream layout/AI navigation behaves identically.
+
+## AI navigator LLMs
+
+- The AI Navigator now calls Ollama first (default `http://192.168.0.71:11434`, model `llama3.1`) and falls back to OpenRouter (`x-ai/grok-4-fast:free`).
+- Configure the OpenRouter API key and base URL from the Settings drawer under the **LLM** tab.
+- When both providers are unreachable the chat surfaces a warning and a quick link to open Settings.
+
+
 ## Desktop build (Tauri)
 
 - Install Tauri CLI: `cargo install tauri-cli --locked`

--- a/docs/CHECKLISTS/CHECKLIST-hkg-defaults-20250926-1356.md
+++ b/docs/CHECKLISTS/CHECKLIST-hkg-defaults-20250926-1356.md
@@ -1,0 +1,39 @@
+# Checklist — HKG Defaults & JSON Loader Verification (2025-09-26 13:56 UTC)
+
+## Legend
+- [ ] — Not started
+- [/] — In progress
+- [x] — Implemented, pending test
+- ✅ — Tested & complete
+
+## Tasks
+1. **Hybrid Knowledge Graph Alignment**
+   - [x] Attempt connectivity check to Neo4j/Qdrant/Postgres endpoints at `192.168.0.71`; document outcome (envoy 503 responses observed).
+   - [ ] Queue sync of this architecture & checklist into hybrid Neo4j store once access to `192.168.0.71` is restored.
+
+2. **Settings Store Hardening (`src/state/settingsStore.ts`)**
+   - [x] Introduce `DEFAULT_SERVICE_CONFIGS` helper mirroring existing defaults to avoid mutation.
+   - [x] Add `sanitizeBaseUrl` utility that trims, removes trailing slash, and returns `null` for empty inputs.
+   - [x] Update `updateUnifiedBaseUrl` to apply sanitizer and fall back to `MCP_DEFAULT` when result is null.
+   - [x] Update `updateService` so blank `baseUrl` reverts to default per service and other fields are trimmed when appropriate.
+   - [x] Ensure `getServiceConfig` and `getMCPBaseUrl` always return a non-empty string (defaulting to 192.168.0.71 host values).
+
+3. **Connection Settings Drawer (`src/components/ConnectionSettingsDrawer.tsx`)**
+   - [x] Ensure UI reflects sanitized values immediately (e.g., by reading values from store after updates rather than stale local state).
+   - [x] Add helper text confirming that clearing a field restores `192.168.0.71` defaults.
+
+4. **JSON Graph Loader (`src/services/jsonGraphLoader.ts`)**
+   - [x] Extend `parseKnowledgeGraphJson` result metadata with `connection_mode: 'file_upload'` and `endpoint` describing file origin.
+   - [x] Include file-derived metadata fields (`source_file_*`) when loading to reinforce audit trail.
+
+5. **Data Source Panel (`src/components/DataSourcePanel.tsx`)**
+   - [x] Display endpoint metadata string (e.g., `endpoint` or `connection_mode`) within the “Last Load” summary.
+   - [x] Confirm JSON upload path surfaces the enriched metadata.
+
+6. **LLM Navigator Verification**
+   - [x] Confirm `navigateWithLLM` still pulls Ollama/OpenRouter endpoints from sanitized settings (manual code inspection post-change).
+   - [x] Update documentation/comments if default host logic changed.
+
+7. **Testing**
+   - [x] Run `npm run lint` to ensure no regressions introduced by changes. *(Fails on pre-existing formatting/type issues; see lint log for details.)*
+   - [x] Document inability to reach external hosts if networking remains blocked. *(Envoy 503 responses recorded.)*

--- a/docs/CHECKLISTS/CHECKLIST-hkg-endpoints-20250926-1316.md
+++ b/docs/CHECKLISTS/CHECKLIST-hkg-endpoints-20250926-1316.md
@@ -1,0 +1,81 @@
+# Checklist — HKG Endpoint Defaults & LLM Navigator Integration (2025-09-26 13:16 UTC)
+
+## Pre-flight
+- [x] Confirm inability to sync hybrid knowledge graph due to offline environment; note in commit message if needed.
+
+## Settings Infrastructure
+- [x] Create `src/state/settingsStore.ts` using Zustand + `persist` middleware storing:
+  - [x] `mode` (`'unified' | 'perService'`) default `'unified'`.
+  - [x] `unified.baseUrl` default `http://192.168.0.71:49160`.
+  - [x] `services` object with keys `neo4j`, `qdrant`, `postgres`, `ollama`, `openRouter` each containing `baseUrl`, optional auth fields (`username`, `password`, `apiKey`, `model`).
+  - [x] Selectors/helpers: `getState().getMCPBaseUrl()`, `getServiceConfig(name)`, `resetToDefaults()`.
+  - [x] Export hook `useSettingsStore` mirroring existing `useStore.use` pattern for selectors needed by components.
+
+## Connection Settings Drawer UI
+- [x] Implement `src/components/ConnectionSettingsDrawer.tsx` featuring:
+  - [x] Floating cog button toggling drawer open state (if not already in AppShell, export control callbacks).
+  - [x] Tabbed interface (`Connections`, `LLM`).
+  - [x] Unified/per-service toggle updating store.
+  - [x] Inputs bound to store values with onChange wiring (text inputs for URLs, credentials; password field for API key with reveal toggle).
+  - [x] Warning about localStorage persistence + Reset button (calls `resetToDefaults`).
+  - [x] Callback prop `onClose` and optional external control via `isOpen` prop.
+
+## AppShell Integration
+- [x] Update `AppShell.tsx` to render `ConnectionSettingsDrawer` and manage open/close state.
+  - [x] Add cog button near existing header or overlay accessible.
+  - [x] Pass `onConnectionChanged` (if needed) or at least ensure DataSourcePanel can signal to open drawer (via context or event bus).
+
+## Data Source Panel Enhancements
+- [x] Inject settings quick-link (e.g., small cog icon) to open settings drawer via prop/callback from `AppShell`.
+- [x] Implement JSON file upload flow when `DATA_SOURCES.FILE` active:
+  - [x] Add drop zone & hidden `<input type="file" accept="application/json">`.
+  - [x] On file selection call new helper `loadGraphFromJsonFile(file)`.
+  - [x] Handle success by calling `loadKnowledgeGraphData` and updating `status['file']` to `'connected'` with `lastLoad` metadata.
+  - [x] Handle validation errors with user-friendly message + `status['file']='error'`.
+  - [x] Preserve existing auto-load logic for other sources.
+
+## JSON Loader Service
+- [x] Create `src/services/jsonGraphLoader.ts` exporting:
+  - [x] `parseKnowledgeGraphJson(raw: unknown)` returning `KnowledgeGraphResult` (reuse type from `hkgLoader`).
+  - [x] `loadGraphFromJsonFile(file: File)` reading text via `file.text()`, parsing JSON, calling validator.
+  - [x] Validation rules: ensure `knowledge_graph.entities` array with objects containing `name`, `type`; `relationships` with `source`, `target`; fill defaults for optional fields; attach metadata timestamp + source `'file_upload'`.
+
+## HKG Loader Updates
+- [x] Modify `hkgLoader.ts`:
+  - [x] Import `useSettingsStore.getState()` (without React hook) for base URLs.
+  - [x] Update `findWorkingMCPServer` to prioritize `settingsStore.getMCPBaseUrl()` then fallback list (`192.168.0.71` variations, env, localhost`).
+  - [x] When per-service mode active, direct each loader to use service-specific base URL if provided.
+  - [x] Ensure fetch helper respects credentials (basic auth for neo4j/postgres, API key header for qdrant if present).
+  - [x] Update return metadata to include `connection_mode` and `endpoint` info.
+
+## Env Config Update
+- [x] Change `src/config/env.ts` default `HKG_MCP_BASE_URL` to `http://192.168.0.71:49160` and expose new helper for fallback when settings absent.
+
+## LLM Client Service
+- [x] Implement `src/services/llmClient.ts` with:
+  - [x] Types `LLMProviderResult`, `LLMError`.
+  - [x] `buildPrompt(context)` summarizing up to 5 entities (name/type/description snippet).
+  - [x] `callOllama(prompt, settings)` using fetch POST to `${ollama.baseUrl}/api/chat` with `model` default `'llama3.1'`, timeout handling.
+  - [x] `callOpenRouter(prompt, settings)` hitting `${openRouter.baseUrl || 'https://openrouter.ai/api/v1/chat/completions'}` with `model` default `'openrouter/x-ai/grok-4-fast:free'`, API key header `Authorization: Bearer ${apiKey}`.
+  - [x] `navigateWithLLM(prompt, context)` orchestrating fallback order (Ollama → OpenRouter) and returning provider + message.
+
+## AI Navigator Update
+- [x] Refactor `AINavigationChat.tsx`:
+  - [x] Inject new prop or context to receive `openSettings` callback for quick access.
+  - [x] Maintain existing keyword-based highlighting and layout suggestions.
+  - [x] Around heuristics results, call `navigateWithLLM` asynchronously, push AI message with provider label and handle spinner state.
+  - [x] On error, show fallback text but include instructions referencing settings.
+  - [x] Display metadata (provider + timestamp) in message bubble.
+
+## Wiring Between Components
+- [x] Ensure `AppShell` passes `onOpenSettings` callback to `DataSourcePanel` and `AINavigationChat` for consistent cog access.
+- [x] Confirm `settingsStore` selectors used without causing React hook misuse (call inside components using `.use` pattern or `useSettingsStore()` hook with selectors).
+
+## Documentation
+- [x] Update README or new doc section summarizing new defaults + settings drawer usage (if necessary).
+- [x] Mention HKG sync limitation note referencing inability to reach remote graph in this environment.
+
+## Post-Implementation
+- [ ] Run `npm run lint` (or equivalent) if available; otherwise document unavailability.
+- [ ] Update checklist item statuses (mark ✅ once tests run and pass).
+- [ ] Prepare final summary referencing new architecture/checklist docs.

--- a/docs/CHECKLISTS/CHECKLIST-hkg-llm-defaults-20250926-1334.md
+++ b/docs/CHECKLISTS/CHECKLIST-hkg-llm-defaults-20250926-1334.md
@@ -1,0 +1,74 @@
+# Checklist — HKG Defaults & LLM Navigator Reliability (2025-09-26 13:34 UTC)
+- **Architecture Reference:** `docs/architecture/ARCHITECTURE-hkg-llm-defaults-20250926-1334.md`
+- **Project UUID:** d04ee192-2eb2-45f5-8375-55380eacbe52
+- **Legend:** [ ] Not started · [/] In progress · [x] Done (untested) · ✅ Tested & complete
+
+## Preparatory Tasks
+1. [x] Capture lint baseline (`npm run lint`) to list current violations affecting touched files.
+2. [x] Inspect hybrid knowledge graph sync status (MCP at 192.168.0.71 unreachable from sandbox; noted for follow-up).
+
+## Settings & Config Defaults
+3. [x] Update `src/state/settingsStore.ts`
+   - [x] Replace exported `.use` convenience with dedicated selector helpers (lint still flags hook naming on property assignments; consider refactor to standalone hooks later).
+   - [x] Define `ConnectionMode`, `EndpointAuth`, `EndpointConfig`, `ServiceKey` types explicitly exported for reuse.
+   - [x] Ensure all default base URLs point to `192.168.0.71` addresses (MCP:49160, Neo4j:7474, Qdrant:6333, Postgres:5432, Ollama:11434) and fallback for OpenRouter base `https://openrouter.ai/api/v1` with default model `openrouter/x-ai/grok-4-fast:free`.
+   - [x] Export pure helper `getServiceConfigSnapshot(key)` for non-hook contexts (services) to avoid lint issues.
+   - [x] Add unit-safe metadata (e.g., `DEFAULT_SERVICE_PORTS` constant) if needed for clarity.
+
+4. [x] Revise `src/config/env.ts`
+   - [x] Confirm fallback base remains `http://192.168.0.71:49160` and add docblock referencing settings store integration.
+
+## Loader & Service Typing
+5. [x] Update `src/services/hkgLoader.ts`
+   - [x] Introduce shared TypeScript interfaces (`KnowledgeGraphMetadata`, `KnowledgeGraphResponse`, etc.) for loader returns.
+   - [x] Replace `any` usage with typed helpers; ensure helper functions return typed Promises.
+   - [x] Refactor base URL retrieval to call `getMCPBaseUrl()` from new settings helper (with env fallback) and ensure trailing slashes trimmed.
+   - [x] Guarantee search + load functions respect connection defaults and propagate thrown errors with context string.
+
+6. [x] Update `src/services/jsonGraphLoader.ts`
+   - [x] Define type-safe coercion for JSON input/output.
+   - [x] Validate JSON schema (entities/nodes/edges) gracefully; include file name + timestamp metadata in result.
+   - [x] Remove `any` and ensure return type aligns with state loader expectations.
+
+7. [x] Update `src/services/llmClient.ts`
+   - [x] Use new settings helper to read service configs without violating hooks lint rules.
+   - [x] Ensure fallback labeling returns `{ provider: 'openrouter' }` when OpenRouter responds and `{ provider: 'fallback' }` if heuristics/resolution occurs otherwise.
+   - [x] Enforce default host `http://192.168.0.71:11434` for Ollama when settings missing.
+   - [x] Improve error messages to guide connection troubleshooting.
+
+## UI Components
+8. [x] Update `src/components/DataSourcePanel.tsx`
+   - [x] Import typed loader results; remove `any` by referencing new interfaces.
+   - [x] Persist `lastLoad` metadata with explicit type and timestamp.
+   - [x] Use selector hooks compliant with eslint (e.g., `const isSidebarOpen = useStore((s) => s.isSidebarOpen)` per project conventions).
+   - [x] Display default IP addresses in tooltip/labels where applicable.
+   - [x] Ensure JSON upload errors render user-friendly text.
+
+9. [x] Update `src/components/AINavigationChat.tsx`
+   - [x] Type `ChatMessage` & matched entity list using shared interfaces.
+   - [x] Distinguish fallback provider text when OpenRouter triggered vs. both failed.
+   - [x] Ensure `useEffect` dependency arrays are correct and `Math.random` usage isolated where necessary.
+   - [x] Provide settings button when provider error occurs.
+
+10. [ ] Update `src/components/AppShell.tsx`
+    - [ ] Wire new selector helpers for settings store (existing usage unaffected; revisit if needed).
+    - [ ] Ensure `ConnectionSettingsDrawer` open/close logic typed and lint-clean.
+
+11. [x] Add/Update `src/components/ConnectionSettingsDrawer.tsx`
+    - [x] Adopt new types from settings store, remove `any`, ensure handlers typed.
+    - [x] Default form fields show `192.168.0.71` values.
+    - [x] Provide inline validation for empty API key when provider selected.
+
+## Documentation
+12. [x] Update `README.md`
+    - [x] Document default IP/port assignments.
+    - [x] Provide instructions for configuring Ollama + OpenRouter credentials.
+    - [x] Mention JSON graph upload workflow.
+
+## Verification
+13. [x] Run `npm run lint` (still failing due to legacy Scene3D/store formatting and hook-pattern violations; see log for follow-up).
+14. [ ] Smoke test via `npm run build` or targeted script if faster (ensure passes).
+15. [/] Summarize results & update checklist statuses accordingly.
+
+## Checklist Sync
+16. [/] Record updated checklist + results in hybrid knowledge graph (pending remote access).

--- a/docs/architecture/ARCHITECTURE-hkg-defaults-20250926-1356.md
+++ b/docs/architecture/ARCHITECTURE-hkg-defaults-20250926-1356.md
@@ -1,0 +1,133 @@
+# Architecture Plan — HKG Defaults & JSON Loader Verification (2025-09-26 13:56 UTC)
+
+## Context & Baseline Repository Abstraction
+- **State Management**
+  - `src/state/settingsStore.ts`
+    - Zustand store managing connection mode (`unified` vs `perService`).
+    - Service configs keyed by `ServiceKey` (Neo4j, Qdrant, PostgreSQL, Ollama, OpenRouter).
+    - Persisted to `localStorage`; exposes selectors (`useSettingsMode`, `useUnifiedBaseUrl`, `useServiceMap`).
+  - `src/state/store.ts`
+    - Primary app state (entities, edges, layout, selection, UI flags).
+- **Services**
+  - `src/services/hkgLoader.ts`
+    - Fetchers for MCP/unified services, typed metadata, heuristics for selecting endpoints.
+  - `src/services/jsonGraphLoader.ts`
+    - Validates uploaded JSON graphs, coercing entity/relationship structures.
+  - `src/services/llmClient.ts`
+    - Invokes Ollama (default `http://192.168.0.71:11434`) and falls back to OpenRouter (`x-ai/grok-4-fast:free`).
+- **UI Components**
+  - `src/components/DataSourcePanel.tsx`
+    - Source selector (Neo4j/Qdrant/Postgres/JSON upload) and orchestrates loads via services.
+  - `src/components/ConnectionSettingsDrawer.tsx`
+    - Cogwheel drawer for configuring endpoints/auth per service or unified MCP base.
+  - `src/components/AINavigationChat.tsx`
+    - Chat interface invoking heuristic entity ranking and `navigateWithLLM` fallback pipeline.
+
+### Repository AST Overview (Key Modules)
+```
+repo
+└── src
+    ├── state
+    │   ├── settingsStore.ts
+    │   └── store.ts
+    ├── services
+    │   ├── hkgLoader.ts
+    │   ├── jsonGraphLoader.ts
+    │   └── llmClient.ts
+    └── components
+        ├── DataSourcePanel.tsx
+        ├── ConnectionSettingsDrawer.tsx
+        └── AINavigationChat.tsx
+```
+
+### Current Alignment with Hybrid Knowledge Graph
+- Latest repo defaults already point to `192.168.0.71`, but blank inputs can persist as empty strings, bypassing fallbacks.
+- JSON loader sets metadata yet omits explicit `connection_mode` to signal file uploads.
+- Unable to sync to shared Neo4j hybrid graph (host unreachable from sandbox); note for follow-up after connectivity returns.
+
+## Proposed Enhancements
+1. **Hardening Default Endpoint Fallbacks**
+   - Sanitize and normalize unified and per-service base URLs in `settingsStore.ts`.
+   - Reapply service-specific defaults (`192.168.0.71` host) whenever values are cleared.
+   - Expose helper to retrieve immutable default configs and use within getters.
+2. **Metadata Clarity for JSON Imports**
+   - Extend `loadGraphFromJsonFile` metadata with `connection_mode: 'file_upload'` and `endpoint` describing uploaded source.
+3. **UI Feedback Consistency**
+   - Ensure `ConnectionSettingsDrawer` reflects sanitized defaults immediately after reset/cleared inputs.
+   - Surface metadata summary in `DataSourcePanel` after JSON/HKG loads to confirm which endpoint responded (leveraging existing status panel).
+
+## UML Component Relationships
+```mermaid
+classDiagram
+    class SettingsStore {
+        +mode: ConnectionMode
+        +unified.baseUrl: string
+        +services: Record<ServiceKey, EndpointConfig>
+        +setMode()
+        +updateUnifiedBaseUrl()
+        +updateService()
+        +resetToDefaults()
+        +getMCPBaseUrl()
+        +getServiceConfig()
+    }
+    class ConnectionSettingsDrawer {
+        +props: { isOpen, onClose }
+        +renders fields per ServiceKey
+        +invokes SettingsStore actions
+    }
+    class DataSourcePanel {
+        +load(source)
+        +handleJsonFile(file)
+        +status map
+    }
+    class JsonGraphLoader {
+        +parseKnowledgeGraphJson()
+        +loadGraphFromJsonFile()
+    }
+    class HkgLoader {
+        +loadFromHKG()
+        +searchShardedHKG()
+        +loadByEntityType()
+    }
+    class LlmClient {
+        +navigateWithLLM()
+        +callOllama()
+        +callOpenRouter()
+    }
+    class AINavigationChat {
+        +send()
+        +processNavigationRequest()
+    }
+
+    ConnectionSettingsDrawer --> SettingsStore
+    DataSourcePanel --> SettingsStore : (via services)
+    DataSourcePanel --> HkgLoader
+    DataSourcePanel --> JsonGraphLoader
+    AINavigationChat --> LlmClient
+    LlmClient --> SettingsStore
+```
+
+## Mermaid Mindmap of Implementation Steps
+```mermaid
+mindmap
+  root((Ensure Defaults & JSON Loader))
+    SettingsStore Hardening
+      Sanitize base URLs
+      Reapply 192.168.0.71 defaults when blank
+      Export helper for default configs
+    JSON Loader Metadata
+      Add connection_mode=file_upload
+      Record endpoint=file://<name>
+    UI Consistency
+      Connection drawer reflects sanitized values
+      Data source status shows endpoint metadata snippet
+```
+
+## Acceptance Criteria
+- Clearing any endpoint field and blurring should revert to its 192.168.0.71 default upon next read.
+- JSON upload metadata includes `connection_mode: 'file_upload'` and `endpoint` referencing the uploaded file.
+- Status panel shows last load metadata with endpoint string so operators confirm the active source.
+- LLM navigator continues to call Ollama first (`http://192.168.0.71:11434`), then OpenRouter `openrouter/x-ai/grok-4-fast:free`.
+
+## Hybrid Knowledge Graph Sync Plan
+- After code updates, re-export architecture/checklist to Neo4j instance tagged with project UUID once network to `192.168.0.71` is available. Logged as follow-up.

--- a/docs/architecture/ARCHITECTURE-hkg-endpoints-20250926-1316.md
+++ b/docs/architecture/ARCHITECTURE-hkg-endpoints-20250926-1316.md
@@ -1,0 +1,154 @@
+# Architecture: HKG Endpoint Defaults & LLM Navigator Integration (2025-09-26 13:16 UTC)
+
+## Context and Goals
+- Ensure every data acquisition path (Neo4j, Qdrant, PostgreSQL, unified hKG MCP) defaults to host **192.168.0.71** while remaining user-configurable.
+- Restore "Load graph from JSON" capability inside the data source panel, including validation and surface status feedback when a JSON knowledge graph is uploaded.
+- Upgrade the AI Navigator chat so that it can call out to **Ollama** first (on the same 192.168.0.71 host) and fall back to **OpenRouter → x-ai/grok-4-fast:free**, blending LLM guidance with existing entity-highlighting behaviors.
+- Surface a cogwheel settings drawer that centralizes connection configuration (unified vs per-service) and LLM credentials, persisted locally for repeat sessions.
+- Note: external hybrid knowledge graph synchronization endpoints are not available in this execution environment; plan includes a stub step documenting how the architecture would be written back when connectivity exists.
+
+## Current Repo Snapshot (High-Level AST Abstraction)
+```
+kg3dnav-cr/
+├── docs/
+│   ├── architecture/                     # ADRs, diagrams
+│   ├── CHECKLISTS/                       # Task breakdowns
+│   └── ...
+├── src/
+│   ├── components/
+│   │   ├── AppShell.tsx                  # top-level shell wiring Canvas3D + Sidebar + panels
+│   │   ├── DataSourcePanel.tsx           # data source selection, options, status badges
+│   │   ├── AINavigationChat.tsx          # heuristic navigator chat (no LLM outbound today)
+│   │   └── ...
+│   ├── config/
+│   │   └── env.ts                        # exposes HKG_MCP_BASE_URL (localhost default)
+│   ├── services/
+│   │   ├── hkgLoader.ts                  # fetch helpers for neo4j/qdrant/postgres via MCP
+│   │   └── layoutEngine.ts               # 3D placement
+│   ├── state/
+│   │   ├── store.ts                      # zustand store for graph + UI state
+│   │   └── actions.ts                    # UI action creators
+│   └── types/
+│       └── knowledge.ts                  # Entity/Relationship typings
+├── index.html / main.tsx                 # React entry
+└── src-tauri/                            # Desktop bridge (unchanged by this feature)
+```
+
+## Proposed Changes Overview
+1. **Connection Settings Layer**
+   - New `state/settingsStore.ts` (Zustand + `persist`) capturing:
+     - `mode: 'unified' | 'perService'`
+     - `unified.baseUrl` (default `http://192.168.0.71:49160`)
+     - Per-service endpoints/credentials: `neo4j`, `qdrant`, `postgres`, `ollama`, `openRouter`.
+     - `openRouter.apiKey` persisted securely (localStorage key, redacted in UI once saved).
+   - Selector helpers: `getMCPBaseUrl()`, `getServiceUrl('neo4j')`, etc., consumed by loaders & LLM client.
+
+2. **Cogwheel Settings Drawer**
+   - New `components/ConnectionSettingsDrawer.tsx` rendered from `AppShell` as floating cog button.
+   - Supports tabs (`Connection`, `LLM`), toggles unified/per-service, input validation, and "Reset to defaults" (reverts to 192.168.0.71).
+   - Visual state: overlay similar to other panels, accessible toggled state stored locally (non-persisted UI flag in drawer component).
+
+3. **Data Source Panel Enhancements**
+   - Introduce JSON upload UI (visible when FILE source active): file drop zone + hidden input.
+   - Parse using new helper `services/jsonGraphLoader.ts` (`loadGraphFromJsonFile(file)` → `KnowledgeGraphResult`), with schema validation (entities array with `name`, `type`; relationships with `source`, `target`).
+   - Provide status updates (success/error) within panel, leveraging existing `status` map.
+   - Add quick link/button to open cogwheel drawer for connection edits.
+
+4. **HKG Loader Wiring**
+   - Update `services/hkgLoader.ts` to source base URLs from `settingsStore` instead of static env default; fallback retains env for legacy use.
+   - Extend `findWorkingMCPServer()` candidate list to prioritise `settingsStore.getState().unified.baseUrl` (192.168.0.71 default) before localhost.
+   - When `mode === 'perService'`, route Neo4j/Qdrant/PostgreSQL requests directly to provided endpoints (bypassing MCP), but still support unified fallback. (Implementation: conditional fetch using service-specific URL + path heuristics, with TODO to align with service API expectations.)
+
+5. **LLM Client Service**
+   - New `services/llmClient.ts` exposing `navigateWithLLM(prompt, context)`:
+     1. Compose system prompt summarizing top entities (limited list) + user message.
+     2. Attempt Ollama: `POST ${ollamaUrl}/api/chat` with model `llama3.1` (configurable) -> parse `message.content`.
+     3. If Ollama fails/timeouts, call OpenRouter `https://openrouter.ai/api/v1/chat/completions` with model `openrouter/x-ai/grok-4-fast:free`, using API key from settings.
+     4. Return text + optionally extracted entity suggestions (via regex/JSON request instructions).
+
+6. **AI Navigation Chat Update**
+   - Replace purely local heuristic response with pipeline:
+     - Keep entity keyword scoring to highlight nodes.
+     - Call `navigateWithLLM` for narrative guidance; merge highlight results with LLM text.
+     - Display provider badges (Ollama/OpenRouter) and handle streaming indicator.
+     - Expose error states gracefully while maintaining heuristics fallback.
+
+7. **Documentation & Graph Sync Hooks**
+   - Note architecture + checklist in `docs/` (this file & new checklist).
+   - Add short operations note inside architecture describing future HKG sync invocation stub (`scripts/sync-hkg-architecture.mjs` placeholder note) since environment lacks connectivity.
+
+## Mermaid Class Diagram (New Settings & Service Integration)
+```mermaid
+classDiagram
+    class SettingsStore {
+        +mode: 'unified' | 'perService'
+        +unified: { baseUrl: string }
+        +services: { neo4j: Endpoint; qdrant: Endpoint; postgres: Endpoint; ollama: Endpoint; openRouter: { baseUrl: string; apiKey?: string; model: string } }
+        +getMCPBaseUrl(): string
+        +getServiceUrl(name): string
+    }
+    class HKGLoader {
+        +findWorkingMCPServer()
+        +loadFromNeo4j(opts)
+        +loadFromQdrant(query)
+        +loadFromPostgreSQL()
+        +loadFromHKG(source)
+    }
+    class LLMClient {
+        +navigateWithLLM(prompt, context): Promise<LLMResult>
+        -callOllama()
+        -callOpenRouter()
+    }
+    class DataSourcePanel {
+        -handleJsonUpload(File)
+        -openSettings()
+    }
+    class ConnectionSettingsDrawer {
+        -modeToggle
+        -inputFields
+    }
+    SettingsStore --> HKGLoader
+    SettingsStore --> LLMClient
+    SettingsStore --> ConnectionSettingsDrawer
+    LLMClient --> AINavigationChat
+    DataSourcePanel --> SettingsStore
+    DataSourcePanel ..> jsonGraphLoader
+```
+
+## Mermaid Sequence (AI Navigation Flow)
+```mermaid
+sequenceDiagram
+    participant User
+    participant Chat as AI Navigator UI
+    participant Heuristics
+    participant LLM as LLMClient
+    participant Ollama
+    participant OpenRouter
+
+    User->>Chat: Enter navigation prompt
+    Chat->>Heuristics: score entities + highlight
+    Chat->>LLM: navigateWithLLM(prompt, context)
+    LLM->>Ollama: POST /api/chat (model=llama3.1)
+    alt Ollama success
+        Ollama-->>LLM: response
+        LLM-->>Chat: {text, provider: "ollama"}
+    else Ollama failure/timeout
+        LLM->>OpenRouter: POST /chat/completions (model=grok-4-fast:free)
+        OpenRouter-->>LLM: response
+        LLM-->>Chat: {text, provider: "openrouter"}
+    end
+    Chat-->>User: Display LLM reply + highlight info
+```
+
+## Risks & Considerations
+- **Endpoint Variability**: Actual Neo4j/Qdrant/Postgres HTTP APIs may diverge from MCP contract; initial implementation focuses on unified MCP path with per-service overrides marked experimental.
+- **Credential Storage**: LocalStorage persistence means secrets live in browser storage; add warnings and allow quick clearing.
+- **LLM Latency/Failures**: Provide UI spinner and fallback heuristics so navigation remains usable when LLM unreachable.
+- **File Upload Validation**: Strict schema checks necessary to avoid crashing renderer; guard with try/catch and user-friendly error.
+
+## Deliverables
+1. `state/settingsStore.ts`, `services/jsonGraphLoader.ts`, `services/llmClient.ts` (new).
+2. Updated `services/hkgLoader.ts`, `config/env.ts`, `components/AppShell.tsx`, `components/DataSourcePanel.tsx`, `components/AINavigationChat.tsx` to wire settings, JSON upload, and LLM integration.
+3. New `components/ConnectionSettingsDrawer.tsx` cogwheel UI (plus styles and open button in AppShell/DataSourcePanel).
+4. Documentation updates (this architecture, checklist under `docs/CHECKLISTS/`).
+5. Placeholder note for future hybrid knowledge graph sync invocation (documented).

--- a/docs/architecture/ARCHITECTURE-hkg-llm-defaults-20250926-1334.md
+++ b/docs/architecture/ARCHITECTURE-hkg-llm-defaults-20250926-1334.md
@@ -1,0 +1,158 @@
+# Architecture Plan — HKG Defaults & LLM Navigator Reliability
+- **Timestamp (UTC):** 2025-09-26 13:34
+- **Project UUID:** d04ee192-2eb2-45f5-8375-55380eacbe52
+- **Authoring Agent:** OpenAI gpt-5-codex
+- **Related Objectives:**
+  1. Ensure all hKG, unified MCP, and per-service endpoints default to `192.168.0.71` addresses when unset.
+  2. Guarantee JSON graph ingestion wiring surfaces metadata and integrates with loader state.
+  3. Harden AI Navigator chat so Ollama primary + OpenRouter (x-ai/grok-4-fast:free) fallback operates with configured credentials and surfaces errors gracefully.
+  4. Resolve eslint/type errors introduced by new settings infrastructure, maintaining deterministic hook usage patterns.
+
+---
+
+## Baseline Repository AST Snapshot
+This condensed AST listing captures the top-level modules and their key exports relevant to data loading & AI navigation. Structures are grouped by domain.
+
+```text
+src/
+├─ components/
+│  ├─ AppShell.tsx — <AppShell> orchestrates panels (DataSourcePanel, AINavigationChat, ConnectionSettingsDrawer).
+│  ├─ DataSourcePanel.tsx — exports default React.FC<DataSourcePanelProps>; internal helpers load() & handleJsonFile(); uses services & store actions.
+│  ├─ AINavigationChat.tsx — exports default React.FC<AINavigationChatProps>; defines ChatMessage type, heuristic NLP helpers, send() invoking navigateWithLLM().
+│  ├─ ConnectionSettingsDrawer.tsx — exports default React.FC; renders drawer UI bound to useSettingsStore selectors.
+│  └─ ... (Canvas3D, Sidebar, etc. unaffected by this change set).
+├─ config/
+│  ├─ env.ts — exports EnvConfig type & getEnvConfig() returning `HKG_MCP_BASE_URL` default.
+├─ services/
+│  ├─ hkgLoader.ts — exports loaders (loadFromHKG, searchShardedHKG, etc.) using fetch against MCP endpoints.
+│  ├─ jsonGraphLoader.ts — exports loadGraphFromJsonFile(File) → ParsedKnowledgeGraphResult.
+│  ├─ llmClient.ts — exports navigateWithLLM(prompt, context) performing Ollama then OpenRouter call sequence.
+│  └─ layoutEngine.ts — (lint impacted; ensure untouched API remains compatible).
+├─ state/
+│  ├─ store.ts — Zustand root store with selectors (use.* pattern).
+│  ├─ actions.ts — state mutators (loadKnowledgeGraphData, etc.).
+│  └─ settingsStore.ts — Zustand persisted store for connection/LLM settings.
+├─ config/
+│  └─ env.ts — ensures MCP default.
+├─ README.md — documents configuration steps.
+└─ docs/architecture, docs/CHECKLISTS — planning artifacts (this doc + checklists).
+```
+
+The AST snapshot validates the relationship chain: `AppShell` mounts `DataSourcePanel` & `AINavigationChat`; both depend on services that must read from `settingsStore` defaults → service fetchers.
+
+---
+
+## Existing Graph Representations
+- `docs/architecture/ARCHITECTURE-hkg-endpoints-20250926-1316.md` already models earlier integration. No divergences detected for component names or file paths; this plan extends the same modules with stricter defaults and lint-safe signatures.
+- No automated sync to the hybrid knowledge graph was possible (network access to shared Neo4j space unavailable). Noted for later reconciliation.
+
+---
+
+## Proposed Solution Architecture
+### Data Flow Overview
+1. **Settings Initialization:** `settingsStore.ts` supplies `DEFAULTS` for unified + per-service endpoints. Ensure each service default uses `192.168.0.71` host (Neo4j 7474, Qdrant 6333, Postgres 5432, Ollama 11434, MCP 49160) and sanitized base URLs.
+2. **Data Source Loader:** `DataSourcePanel` leverages settings store when calling `hkgLoader` methods; `loadGraphFromJsonFile` needs enriched metadata (timestamp, file name) and typed return contract to integrate with `loadKnowledgeGraphData`.
+3. **HKG Services:** `hkgLoader.ts` centralizes base URL retrieval via `getEnvConfig` + `useSettingsStore.getState().getMCPBaseUrl()`; unify type definitions for loader responses to avoid `any`.
+4. **LLM Client:** `llmClient.ts` obtains Ollama/OpenRouter configs via store, ensures fallback path communicates errors. Provide explicit types & sanitized URLs, support `openrouter/x-ai/grok-4-fast:free` default.
+5. **UI Wiring:**
+   - `AppShell.tsx` toggles `ConnectionSettingsDrawer`, passes handlers to `DataSourcePanel` & `AINavigationChat`.
+   - `AINavigationChat` handles asynchronous message updates; ensure provider labeling aligns with actual fallback (set `'fallback'` when OpenRouter responds after Ollama failure).
+   - `DataSourcePanel` displays settings gear, handles JSON upload, updates status badges.
+
+### Component Interaction Diagram (Mermaid UML)
+```mermaid
+classDiagram
+    class AppShell {
+      +useState drawerOpen
+      +render(): JSX.Element
+    }
+    class ConnectionSettingsDrawer {
+      +props: {open:boolean, onClose:fn}
+      +handleSave()
+    }
+    class DataSourcePanel {
+      +props: {onOpenSettings?:fn}
+      +load(source)
+      +handleJsonFile(file)
+    }
+    class AINavigationChat {
+      +props: {onOpenSettings?:fn}
+      +send()
+      +processNavigationRequest()
+    }
+    class settingsStore {
+      +getMCPBaseUrl():string
+      +getServiceConfig(key):EndpointConfig
+    }
+    class hkgLoader {
+      +loadFromHKG(mode)
+      +searchShardedHKG(query, opts)
+    }
+    class jsonGraphLoader {
+      +loadGraphFromJsonFile(file):Promise<KGLoadResult>
+    }
+    class llmClient {
+      +navigateWithLLM(prompt, ctx):Promise<LLMResult>
+    }
+
+    AppShell --> ConnectionSettingsDrawer
+    AppShell --> DataSourcePanel
+    AppShell --> AINavigationChat
+    DataSourcePanel --> hkgLoader
+    DataSourcePanel --> jsonGraphLoader
+    DataSourcePanel --> settingsStore
+    AINavigationChat --> llmClient
+    hkgLoader --> settingsStore
+    llmClient --> settingsStore
+```
+
+### Mermaid Mindmap (MMD)
+```mermaid
+mindmap
+  root((HKG Defaults & LLM Navigator))
+    Settings
+      Unified MCP 192.168.0.71:49160
+      Per-service
+        Neo4j 7474
+        Qdrant 6333
+        Postgres 5432
+        Ollama 11434
+        OpenRouter API base
+    Loaders
+      JSON Loader
+        Validate schema
+        Emit metadata timestamp/name
+      HKG Loader
+        Typed responses
+        Uses MCP base from settings/env
+    UI
+      DataSourcePanel
+        Source status chips
+        JSON upload error handling
+      ConnectionSettingsDrawer
+        Persist to localStorage
+      AI Navigator Chat
+        Heuristic guidance
+        LLM invocation & fallback status
+    Services
+      LLM Client
+        Ollama primary
+        OpenRouter fallback (grok-4-fast)
+      Store
+        Zustand selectors without lint issues
+```
+
+---
+
+## Implementation Considerations
+- Replace `any` usages with shared interfaces (define `KnowledgeGraphResult`, `LoaderStatus`, etc.) to resolve linting.
+- Adopt selector hooks within components instead of exported `.use` property to satisfy React hooks lint rule; provide typed helper selectors outside components for reuse.
+- Update JSON loader to include metadata (timestamp ISO string, source type `file`).
+- Ensure fallback labeling in chat distinguishes OpenRouter fallback vs heuristics.
+- Confirm README instructions mention new defaults + requirement for OpenRouter API key + Ollama host.
+
+---
+
+## Hybrid Knowledge Graph Sync
+Unable to push architecture into shared Neo4j hybrid graph due to environment access limits. Documenting the new plan locally; pending sync operation noted for follow-up once connectivity to `192.168.0.71` graph instance is available.
+

--- a/src/components/AINavigationChat.tsx
+++ b/src/components/AINavigationChat.tsx
@@ -1,30 +1,74 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef, useState } from 'react'
-import useStore from '../state/store'
+import { useEntities } from '../state/store'
 import { highlightEntities, setTargetEntity, setLayout } from '../state/actions'
+import { navigateWithLLM } from '../services/llmClient'
+import type { Entity } from '../types/knowledge'
 
-export default function AINavigationChat(): JSX.Element {
+type RankedEntity = Entity & { score: number }
+
+type ChatMessage = {
+  id: string
+  type: 'user' | 'ai'
+  content: string
+  matchedEntities?: RankedEntity[]
+  action?: string
+  timestamp: Date
+  provider?: 'heuristic' | 'ollama' | 'openrouter' | 'error' | 'fallback'
+}
+
+type AINavigationChatProps = {
+  onOpenSettings?: () => void
+}
+
+export default function AINavigationChat({ onOpenSettings }: AINavigationChatProps): JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
-  const [messages, setMessages] = useState<{ type: 'user' | 'ai'; content: string; matchedEntities?: any[]; action?: string; timestamp: Date }[]>([])
+  const [messages, setMessages] = useState<ChatMessage[]>([])
   const [inputValue, setInputValue] = useState('')
   const [isProcessing, setIsProcessing] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
 
-  const entities = useStore.use.entities()
+  function generateId(prefix: string) {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  }
 
-  useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }) }, [messages])
-  useEffect(() => { if (isOpen) inputRef.current?.focus() }, [isOpen])
+  const entities = useEntities()
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+  useEffect(() => {
+    if (isOpen) inputRef.current?.focus()
+  }, [isOpen])
   useEffect(() => {
     if (messages.length === 0) {
-      setMessages([{ type: 'ai', content: 'Hello! Ask me to "show me" or "navigate to" concepts, people, places, or events.', timestamp: new Date() }])
+      setMessages([
+        {
+          id: generateId('ai'),
+          type: 'ai',
+          content: 'Hello! Ask me to "show me" or "navigate to" concepts, people, places, or events.',
+          timestamp: new Date(),
+          provider: 'heuristic',
+        },
+      ])
     }
   }, [])
 
-  async function processNavigationRequest(userQuery: string) {
+  type NavigationAnalysis = {
+    content: string
+    matchedEntities: RankedEntity[]
+    action: 'navigate' | 'search' | 'explore' | 'none' | 'error'
+  }
+
+  async function processNavigationRequest(userQuery: string): Promise<NavigationAnalysis> {
     try {
       const q = userQuery.toLowerCase()
-      let action = q.match(/\b(fly|navigate|go to|show me)\b/) ? 'navigate' : q.match(/\b(find|search|locate)\b/) ? 'search' : 'explore'
+      const action = q.match(/\b(fly|navigate|go to|show me)\b/)
+        ? 'navigate'
+        : q.match(/\b(find|search|locate)\b/)
+          ? 'search'
+          : 'explore'
       const keywords = extractKeywords(q)
       const matches = findMatchingEntities(keywords)
       if (matches.length > 0) {
@@ -37,17 +81,47 @@ export default function AINavigationChat(): JSX.Element {
       return { content: noMatchResponse(userQuery, keywords), matchedEntities: [], action: 'none' }
     } catch (e) {
       console.error('AI nav error:', e)
-      return { content: 'I encountered an issue. Please try rephrasing your request.', matchedEntities: [], action: 'error' }
+      return {
+        content: 'I encountered an issue. Please try rephrasing your request.',
+        matchedEntities: [],
+        action: 'error',
+      }
     }
   }
 
   function extractKeywords(q: string) {
-    const stop = new Set(['the','to','and','or','but','in','on','at','by','for','with','from','fly','navigate','go','show','me','find','search','locate','take','bring'])
-    return q.replace(/[^\w\s]/g, ' ').split(/\s+/).filter((w) => w.length > 2 && !stop.has(w))
+    const stop = new Set([
+      'the',
+      'to',
+      'and',
+      'or',
+      'but',
+      'in',
+      'on',
+      'at',
+      'by',
+      'for',
+      'with',
+      'from',
+      'fly',
+      'navigate',
+      'go',
+      'show',
+      'me',
+      'find',
+      'search',
+      'locate',
+      'take',
+      'bring',
+    ])
+    return q
+      .replace(/[^\w\s]/g, ' ')
+      .split(/\s+/)
+      .filter((w) => w.length > 2 && !stop.has(w))
   }
 
-  function findMatchingEntities(keywords: string[]) {
-    const matches: any[] = []
+  function findMatchingEntities(keywords: string[]): RankedEntity[] {
+    const matches: RankedEntity[] = []
     entities.forEach((e) => {
       let score = 0
       for (const k of keywords) {
@@ -55,19 +129,50 @@ export default function AINavigationChat(): JSX.Element {
         if (e.description?.toLowerCase().includes(k)) score += 5
         if (e.type.toLowerCase().includes(k)) score += 3
       }
-      const hist = ['historical','ancient','medieval','renaissance','modern','contemporary','century','era','period','gutenberg','printing','press']
-      if (keywords.some((k) => hist.includes(k)) && (e.type === 'EVENT' || /\d{2,4}/.test(e.name))) score += 15
-      const conceptTerms = ['concept','idea','theory','principle','anthropological','sociological','cultural','social','primitive','artifact','divergence']
+      const hist = [
+        'historical',
+        'ancient',
+        'medieval',
+        'renaissance',
+        'modern',
+        'contemporary',
+        'century',
+        'era',
+        'period',
+        'gutenberg',
+        'printing',
+        'press',
+      ]
+      if (keywords.some((k) => hist.includes(k)) && (e.type === 'EVENT' || /\d{2,4}/.test(e.name)))
+        score += 15
+      const conceptTerms = [
+        'concept',
+        'idea',
+        'theory',
+        'principle',
+        'anthropological',
+        'sociological',
+        'cultural',
+        'social',
+        'primitive',
+        'artifact',
+        'divergence',
+      ]
       if (keywords.some((k) => conceptTerms.includes(k)) && e.type === 'CONCEPT') score += 12
       if (score > 0) matches.push({ ...e, score })
     })
     return matches.sort((a, b) => b.score - a.score).slice(0, 8)
   }
 
-  function responseFor(action: string, list: any[], original: string) {
-    if (list.length === 1) return `🎯 Navigating to "${list[0].name}" (${list[0].type}). ${list[0].description || ''}`
-    if (list.length <= 3) return `🔍 Found ${list.length} relevant entities: ${list.map((e) => `"${e.name}"`).join(', ')}.`
-    return `📍 Found ${list.length} entities. Top: ${list.slice(0,3).map((e)=>`"${e.name}"`).join(', ')} and ${list.length-3} more.`
+  function responseFor(action: string, list: RankedEntity[], original: string) {
+    if (list.length === 1)
+      return `🎯 Navigating to "${list[0].name}" (${list[0].type}). ${list[0].description || ''}`
+    if (list.length <= 3)
+      return `🔍 Found ${list.length} relevant entities: ${list.map((e) => `"${e.name}"`).join(', ')}.`
+    return `📍 Found ${list.length} entities. Top: ${list
+      .slice(0, 3)
+      .map((e) => `"${e.name}"`)
+      .join(', ')} and ${list.length - 3} more.`
   }
 
   function noMatchResponse(query: string, keywords: string[]) {
@@ -81,57 +186,256 @@ export default function AINavigationChat(): JSX.Element {
     return `🤔 I couldn't find matches for "${query}". ${s}.`
   }
 
-  function suggestLayout(matched: any[]) {
+  function suggestLayout(matched: RankedEntity[]) {
     const types = new Set(matched.map((e) => e.type))
-    if (types.has('CONCEPT') && matched.filter((e) => e.type === 'CONCEPT').length >= 2) setLayout('concept-centric')
+    if (types.has('CONCEPT') && matched.filter((e) => e.type === 'CONCEPT').length >= 2)
+      setLayout('concept-centric')
     else if (types.size > 2) setLayout('sphere')
   }
 
   async function send() {
     if (!inputValue.trim() || isProcessing) return
-    const msg = { type: 'user' as const, content: inputValue.trim(), timestamp: new Date() }
+    const msg = {
+      id: generateId('user'),
+      type: 'user' as const,
+      content: inputValue.trim(),
+      timestamp: new Date(),
+    }
     setMessages((p) => [...p, msg])
     setInputValue('')
     setIsProcessing(true)
     const res = await processNavigationRequest(msg.content)
-    setMessages((p) => [...p, { type: 'ai', content: res.content, matchedEntities: res.matchedEntities, action: res.action, timestamp: new Date() }])
-    setIsProcessing(false)
+    const aiMessageId = generateId('ai')
+    setMessages((p) => [
+      ...p,
+      {
+        id: aiMessageId,
+        type: 'ai',
+        content: `${res.content}
+
+Fetching guidance from navigation LLM...`,
+        matchedEntities: res.matchedEntities,
+        action: res.action,
+        timestamp: new Date(),
+        provider: 'heuristic',
+      },
+    ])
+    try {
+      const llmResult = await navigateWithLLM(msg.content, {
+        matches: res.matchedEntities || [],
+        action: res.action,
+      })
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === aiMessageId
+            ? {
+                ...m,
+                content: `${res.content}
+
+${llmResult.message}`,
+                provider: llmResult.provider || 'heuristic',
+              }
+            : m
+        )
+      )
+    } catch (err) {
+      const fallback = '⚠️ Unable to reach Ollama/OpenRouter. Check your connection settings.'
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === aiMessageId
+            ? {
+                ...m,
+                content: `${res.content}
+
+${fallback}`,
+                provider: 'error',
+              }
+            : m
+        )
+      )
+    } finally {
+      setIsProcessing(false)
+    }
   }
 
   return !isOpen ? (
     <button
       onClick={() => setIsOpen(true)}
-      style={{ position: 'absolute', bottom: 120, left: 20, background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', border: 'none', borderRadius: 50, padding: '15px 20px', color: 'white', cursor: 'pointer', fontSize: 14, fontWeight: 500, backdropFilter: 'blur(10px)', borderStyle: 'solid', borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)', boxShadow: '0 8px 32px rgba(102,126,234,0.4)' }}
+      style={{
+        position: 'absolute',
+        bottom: 120,
+        left: 20,
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        border: 'none',
+        borderRadius: 50,
+        padding: '15px 20px',
+        color: 'white',
+        cursor: 'pointer',
+        fontSize: 14,
+        fontWeight: 500,
+        backdropFilter: 'blur(10px)',
+        borderStyle: 'solid',
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.2)',
+        boxShadow: '0 8px 32px rgba(102,126,234,0.4)',
+      }}
       title="AI Navigator"
     >
       🧭 AI Navigator
     </button>
   ) : (
     <div
-      style={{ position: 'absolute', bottom: 120, left: 20, width: 400, height: 500, background: 'rgba(0, 0, 0, 0.92)', borderRadius: 16, backdropFilter: 'blur(20px)', border: '1px solid rgba(255, 255, 255, 0.1)', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '0 20px 60px rgba(0,0,0,0.5)' }}
+      style={{
+        position: 'absolute',
+        bottom: 120,
+        left: 20,
+        width: 400,
+        height: 500,
+        background: 'rgba(0, 0, 0, 0.92)',
+        borderRadius: 16,
+        backdropFilter: 'blur(20px)',
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+      }}
     >
-      <div style={{ padding: 20, borderBottom: '1px solid rgba(255,255,255,0.1)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'linear-gradient(135deg, rgba(102,126,234,0.1) 0%, rgba(118,75,162,0.1) 100%)' }}>
+      <div
+        style={{
+          padding: 20,
+          borderBottom: '1px solid rgba(255,255,255,0.1)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          background: 'linear-gradient(135deg, rgba(102,126,234,0.1) 0%, rgba(118,75,162,0.1) 100%)',
+        }}
+      >
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <span style={{ fontSize: 20 }}>🧭</span>
           <div>
             <div style={{ color: 'white', fontWeight: 600, fontSize: 16 }}>AI Navigator</div>
-            <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 12 }}>Natural language graph exploration</div>
+            <div style={{ color: 'rgba(255,255,255,0.7)', fontSize: 12 }}>
+              Natural language graph exploration
+            </div>
           </div>
         </div>
-        <button onClick={() => setIsOpen(false)} style={{ background: 'none', border: 'none', color: 'rgba(255,255,255,0.7)', fontSize: 20, cursor: 'pointer', padding: 5, borderRadius: '50%' }} title="Close">×</button>
+        <button
+          onClick={() => setIsOpen(false)}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'rgba(255,255,255,0.7)',
+            fontSize: 20,
+            cursor: 'pointer',
+            padding: 5,
+            borderRadius: '50%',
+          }}
+          title="Close"
+        >
+          ×
+        </button>
       </div>
 
-      <div style={{ flex: 1, padding: 20, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 15 }}>
-        {messages.map((m, i) => (
-          <div key={i} style={{ display: 'flex', flexDirection: m.type === 'user' ? 'row-reverse' : 'row', gap: 10, alignItems: 'flex-start' }}>
-            <div style={{ width: 32, height: 32, borderRadius: '50%', background: m.type === 'user' ? 'linear-gradient(135deg, #4ECDC4 0%, #44A08D 100%)' : 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14, flexShrink: 0 }}>{m.type === 'user' ? '👤' : '🧭'}</div>
-            <div style={{ background: m.type === 'user' ? 'rgba(78,205,196,0.2)' : 'rgba(255,255,255,0.05)', padding: '12px 16px', borderRadius: 12, color: 'white', fontSize: 14, lineHeight: 1.4, maxWidth: 280, border: m.type === 'user' ? '1px solid rgba(78,205,196,0.3)' : '1px solid rgba(255,255,255,0.1)' }}>
-              {m.content}
+      <div
+        style={{ flex: 1, padding: 20, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 15 }}
+      >
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            style={{
+              display: 'flex',
+              flexDirection: m.type === 'user' ? 'row-reverse' : 'row',
+              gap: 10,
+              alignItems: 'flex-start',
+            }}
+          >
+            <div
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: '50%',
+                background:
+                  m.type === 'user'
+                    ? 'linear-gradient(135deg, #4ECDC4 0%, #44A08D 100%)'
+                    : 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 14,
+                flexShrink: 0,
+              }}
+            >
+              {m.type === 'user' ? '👤' : '🧭'}
+            </div>
+            <div
+              style={{
+                background: m.type === 'user' ? 'rgba(78,205,196,0.2)' : 'rgba(255,255,255,0.05)',
+                padding: '12px 16px',
+                borderRadius: 12,
+                color: 'white',
+                fontSize: 14,
+                lineHeight: 1.4,
+                maxWidth: 280,
+                border:
+                  m.type === 'user' ? '1px solid rgba(78,205,196,0.3)' : '1px solid rgba(255,255,255,0.1)',
+              }}
+            >
+              {m.content.split('\n').map((line, idx) => (
+                <div key={idx}>{line}</div>
+              ))}
+              {m.provider && m.type === 'ai' && (
+                <div
+                  style={{
+                    marginTop: 6,
+                    fontSize: 10,
+                    color: 'rgba(255,255,255,0.6)',
+                    letterSpacing: 0.8,
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  {m.provider === 'ollama' && 'Ollama response'}
+                  {m.provider === 'openrouter' && 'OpenRouter • x-ai/grok-4-fast:free'}
+                  {m.provider === 'heuristic' && 'Heuristic guidance'}
+                  {m.provider === 'error' && 'LLM unavailable'}
+                  {m.provider === 'fallback' && 'Fallback response'}
+                </div>
+              )}
+              {m.provider === 'error' && onOpenSettings && (
+                <button
+                  onClick={() => onOpenSettings()}
+                  style={{
+                    marginTop: 6,
+                    background: 'rgba(255,255,255,0.1)',
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    borderRadius: 8,
+                    color: 'white',
+                    fontSize: 12,
+                    padding: '4px 8px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  Open settings
+                </button>
+              )}
+
               {!!m.matchedEntities?.length && (
-                <div style={{ marginTop: 8, padding: 8, background: 'rgba(0,0,0,0.3)', borderRadius: 6, fontSize: 12 }}>
-                  <div style={{ fontWeight: 500, marginBottom: 4 }}>Highlighted: {m.matchedEntities.length} entities</div>
-                  {m.matchedEntities.slice(0,3).map((e) => (
-                    <div key={e.name} style={{ color: 'rgba(255,255,255,0.8)' }}>• {e.name} ({e.type})</div>
+                <div
+                  style={{
+                    marginTop: 8,
+                    padding: 8,
+                    background: 'rgba(0,0,0,0.3)',
+                    borderRadius: 6,
+                    fontSize: 12,
+                  }}
+                >
+                  <div style={{ fontWeight: 500, marginBottom: 4 }}>
+                    Highlighted: {m.matchedEntities.length} entities
+                  </div>
+                  {m.matchedEntities.slice(0, 3).map((e) => (
+                    <div key={e.name} style={{ color: 'rgba(255,255,255,0.8)' }}>
+                      • {e.name} ({e.type})
+                    </div>
                   ))}
                 </div>
               )}
@@ -140,9 +444,42 @@ export default function AINavigationChat(): JSX.Element {
         ))}
         {isProcessing && (
           <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-            <div style={{ width: 32, height: 32, borderRadius: '50%', background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>🧭</div>
-            <div style={{ background: 'rgba(255,255,255,0.05)', padding: '12px 16px', borderRadius: 12, border: '1px solid rgba(255,255,255,0.1)', display: 'flex', alignItems: 'center', gap: 8, color: 'rgba(255,255,255,0.7)', fontSize: 14 }}>
-              <div style={{ width: 12, height: 12, border: '2px solid rgba(255,255,255,0.3)', borderTop: '2px solid white', borderRadius: '50%', animation: 'spin 1s linear infinite' }} />
+            <div
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: '50%',
+                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              🧭
+            </div>
+            <div
+              style={{
+                background: 'rgba(255,255,255,0.05)',
+                padding: '12px 16px',
+                borderRadius: 12,
+                border: '1px solid rgba(255,255,255,0.1)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                color: 'rgba(255,255,255,0.7)',
+                fontSize: 14,
+              }}
+            >
+              <div
+                style={{
+                  width: 12,
+                  height: 12,
+                  border: '2px solid rgba(255,255,255,0.3)',
+                  borderTop: '2px solid white',
+                  borderRadius: '50%',
+                  animation: 'spin 1s linear infinite',
+                }}
+              />
               Navigating...
             </div>
           </div>
@@ -150,18 +487,62 @@ export default function AINavigationChat(): JSX.Element {
         <div ref={messagesEndRef} />
       </div>
 
-      <div style={{ padding: 20, borderTop: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.02)' }}>
+      <div
+        style={{
+          padding: 20,
+          borderTop: '1px solid rgba(255,255,255,0.1)',
+          background: 'rgba(255,255,255,0.02)',
+        }}
+      >
         <div style={{ display: 'flex', gap: 10 }}>
           <input
             ref={inputRef}
             value={inputValue}
             onChange={(e) => setInputValue((e.target as HTMLInputElement).value)}
-            onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void send() } }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                void send()
+              }
+            }}
             placeholder="Navigate to concepts about..."
             disabled={isProcessing}
-            style={{ flex: 1, padding: '12px 16px', background: 'rgba(255,255,255,0.1)', borderStyle: 'solid', borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)', borderRadius: 25, color: 'white', fontSize: 14, outline: 'none' }}
+            style={{
+              flex: 1,
+              padding: '12px 16px',
+              background: 'rgba(255,255,255,0.1)',
+              borderStyle: 'solid',
+              borderWidth: 1,
+              borderColor: 'rgba(255,255,255,0.2)',
+              borderRadius: 25,
+              color: 'white',
+              fontSize: 14,
+              outline: 'none',
+            }}
           />
-          <button onClick={() => void send()} disabled={!inputValue.trim() || isProcessing} style={{ background: inputValue.trim() && !isProcessing ? 'linear-gradient(135deg, #4ECDC4 0%, #44A08D 100%)' : 'rgba(255,255,255,0.1)', border: 'none', borderRadius: '50%', width: 44, height: 44, color: 'white', cursor: inputValue.trim() && !isProcessing ? 'pointer' : 'not-allowed', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16 }}> {isProcessing ? '⏳' : '🚀'} </button>
+          <button
+            onClick={() => void send()}
+            disabled={!inputValue.trim() || isProcessing}
+            style={{
+              background:
+                inputValue.trim() && !isProcessing
+                  ? 'linear-gradient(135deg, #4ECDC4 0%, #44A08D 100%)'
+                  : 'rgba(255,255,255,0.1)',
+              border: 'none',
+              borderRadius: '50%',
+              width: 44,
+              height: 44,
+              color: 'white',
+              cursor: inputValue.trim() && !isProcessing ? 'pointer' : 'not-allowed',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 16,
+            }}
+          >
+            {' '}
+            {isProcessing ? '⏳' : '🚀'}{' '}
+          </button>
         </div>
       </div>
 
@@ -169,4 +550,3 @@ export default function AINavigationChat(): JSX.Element {
     </div>
   )
 }
-

--- a/src/components/ConnectionSettingsDrawer.tsx
+++ b/src/components/ConnectionSettingsDrawer.tsx
@@ -1,0 +1,568 @@
+// SPDX-License-Identifier: Apache-2.0
+import React, { useMemo, useState } from 'react'
+import useSettingsStore, {
+  ServiceKey,
+  useSettingsMode,
+  useUnifiedBaseUrl,
+  useServiceMap,
+  DEFAULT_SERVICE_ENDPOINTS,
+  MCP_DEFAULT,
+} from '../state/settingsStore'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+type Tab = 'connections' | 'llm'
+
+const SERVICE_METADATA: Record<
+  ServiceKey,
+  {
+    label: string
+    description: string
+    fields: Array<{
+      key: 'baseUrl' | 'username' | 'password' | 'apiKey' | 'model'
+      label: string
+      type?: 'text' | 'password'
+      placeholder?: string
+      helper?: string
+    }>
+  }
+> = {
+  neo4j: {
+    label: 'Neo4j',
+    description: 'Graph database backing the knowledge graph.',
+    fields: [
+      { key: 'baseUrl', label: 'Base URL', placeholder: 'http://192.168.0.71:7474' },
+      { key: 'username', label: 'Username', placeholder: 'neo4j' },
+      { key: 'password', label: 'Password', type: 'password', placeholder: '••••••' },
+    ],
+  },
+  qdrant: {
+    label: 'Qdrant',
+    description: 'Vector search service for embeddings.',
+    fields: [
+      { key: 'baseUrl', label: 'Base URL', placeholder: 'http://192.168.0.71:6333' },
+      { key: 'apiKey', label: 'API Key', type: 'password', placeholder: 'Optional' },
+    ],
+  },
+  postgres: {
+    label: 'PostgreSQL',
+    description: 'Audit/event persistence backing knowledge graph actions.',
+    fields: [
+      { key: 'baseUrl', label: 'Connection URL', placeholder: 'postgresql://192.168.0.71:5432' },
+      { key: 'username', label: 'Username', placeholder: 'postgres' },
+      { key: 'password', label: 'Password', type: 'password', placeholder: '••••••' },
+    ],
+  },
+  ollama: {
+    label: 'Ollama',
+    description: 'Local LLM runtime used for first-pass navigation guidance.',
+    fields: [
+      { key: 'baseUrl', label: 'Base URL', placeholder: 'http://192.168.0.71:11434' },
+      { key: 'model', label: 'Model', placeholder: 'llama3.1' },
+    ],
+  },
+  openRouter: {
+    label: 'OpenRouter (x-ai/grok-4-fast:free)',
+    description: 'Fallback hosted LLM provider via OpenRouter API.',
+    fields: [
+      { key: 'baseUrl', label: 'Base URL', placeholder: 'https://openrouter.ai/api/v1' },
+      {
+        key: 'apiKey',
+        label: 'API Key',
+        type: 'password',
+        placeholder: 'sk-...',
+        helper: 'Stored locally in your browser (never sent elsewhere).',
+      },
+      { key: 'model', label: 'Model', placeholder: 'openrouter/x-ai/grok-4-fast:free' },
+    ],
+  },
+}
+
+const ConnectionSettingsDrawer: React.FC<Props> = ({ isOpen, onClose }) => {
+  const mode = useSettingsMode()
+  const unifiedBaseUrl = useUnifiedBaseUrl()
+  const services = useServiceMap()
+
+  const setMode = useSettingsStore((s) => s.setMode)
+  const updateUnifiedBaseUrl = useSettingsStore((s) => s.updateUnifiedBaseUrl)
+  const updateService = useSettingsStore((s) => s.updateService)
+  const resetToDefaults = useSettingsStore((s) => s.resetToDefaults)
+
+  const [activeTab, setActiveTab] = useState<Tab>('connections')
+  const [revealApiKey, setRevealApiKey] = useState(false)
+
+  const serviceKeys = useMemo(() => Object.keys(services) as ServiceKey[], [services])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        width: 420,
+        height: '100vh',
+        background: 'rgba(10, 12, 16, 0.96)',
+        borderLeft: '1px solid rgba(255,255,255,0.12)',
+        boxShadow: '-20px 0 40px rgba(0,0,0,0.4)',
+        backdropFilter: 'blur(12px)',
+        color: 'white',
+        zIndex: 1200,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        style={{
+          padding: '18px 20px',
+          borderBottom: '1px solid rgba(255,255,255,0.1)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span role="img" aria-label="settings">
+              ⚙️
+            </span>
+            Connection Settings
+          </div>
+          <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.7)', marginTop: 4 }}>
+            Defaults point to 192.168.0.71; update to match your deployment.
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'transparent',
+            color: 'rgba(255,255,255,0.7)',
+            border: 'none',
+            fontSize: 20,
+            cursor: 'pointer',
+          }}
+          title="Close settings"
+        >
+          ×
+        </button>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          padding: '14px 20px',
+          borderBottom: '1px solid rgba(255,255,255,0.08)',
+        }}
+      >
+        {(
+          [
+            { key: 'connections', label: 'Connections' },
+            { key: 'llm', label: 'LLM' },
+          ] as Array<{ key: Tab; label: string }>
+        ).map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            style={{
+              padding: '6px 14px',
+              borderRadius: 999,
+              border: '1px solid rgba(255,255,255,0.15)',
+              background: activeTab === tab.key ? 'rgba(78,205,196,0.2)' : 'transparent',
+              color: 'white',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: 20 }}>
+        {activeTab === 'connections' ? (
+          <>
+            <div style={{ marginBottom: 20 }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13 }}>
+                <input
+                  type="radio"
+                  name="connection-mode"
+                  value="unified"
+                  checked={mode === 'unified'}
+                  onChange={() => setMode('unified')}
+                  style={{ accentColor: '#4ECDC4' }}
+                />
+                Unified MCP Endpoint (recommended)
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, marginTop: 10 }}>
+                <input
+                  type="radio"
+                  name="connection-mode"
+                  value="perService"
+                  checked={mode === 'perService'}
+                  onChange={() => setMode('perService')}
+                  style={{ accentColor: '#4ECDC4' }}
+                />
+                Configure individual service endpoints
+              </label>
+            </div>
+
+            <div
+              style={{
+                marginBottom: 24,
+                padding: 16,
+                background: 'rgba(255,255,255,0.05)',
+                borderRadius: 12,
+                border: '1px solid rgba(255,255,255,0.08)',
+              }}
+            >
+              <label
+                style={{ display: 'block', fontSize: 12, color: 'rgba(255,255,255,0.75)', marginBottom: 6 }}
+              >
+                Unified MCP Base URL
+              </label>
+              <input
+                type="text"
+                value={unifiedBaseUrl}
+                onChange={(e) => updateUnifiedBaseUrl((e.target as HTMLInputElement).value)}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: '1px solid rgba(255,255,255,0.2)',
+                  background: 'rgba(0,0,0,0.3)',
+                  color: 'white',
+                  fontSize: 13,
+                }}
+                placeholder="http://192.168.0.71:49160"
+              />
+              <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', marginTop: 6 }}>
+                Used for all data sources when "Unified" mode is selected.
+              </div>
+              <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.45)', marginTop: 4 }}>
+                Clearing this field restores the default {MCP_DEFAULT} endpoint.
+              </div>
+            </div>
+
+            {mode === 'perService' && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                {serviceKeys.map((key) => {
+                  const config = services[key]
+                  const meta = SERVICE_METADATA[key]
+                  if (!meta) return null
+                  return (
+                    <div
+                      key={key}
+                      style={{
+                        padding: 16,
+                        borderRadius: 12,
+                        border: '1px solid rgba(255,255,255,0.1)',
+                        background: 'rgba(255,255,255,0.02)',
+                      }}
+                    >
+                      <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>{meta.label}</div>
+                      <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', marginBottom: 12 }}>
+                        {meta.description}
+                      </div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                        {meta.fields.map((field) => {
+                          const type = field.type ?? 'text'
+                          const value = config[field.key] ?? ''
+                          const isApiKey = field.key === 'apiKey' && key === 'openRouter'
+                          const inputType = isApiKey && !revealApiKey ? 'password' : type
+                          const defaultBase =
+                            field.key === 'baseUrl'
+                              ? key === 'openRouter'
+                                ? DEFAULT_SERVICE_ENDPOINTS.openRouter
+                                : DEFAULT_SERVICE_ENDPOINTS[key]
+                              : null
+                          return (
+                            <div key={field.key}>
+                              <label
+                                style={{
+                                  display: 'block',
+                                  fontSize: 12,
+                                  color: 'rgba(255,255,255,0.75)',
+                                  marginBottom: 4,
+                                }}
+                              >
+                                {field.label}
+                              </label>
+                              <div style={{ position: 'relative' }}>
+                                <input
+                                  type={inputType}
+                                  value={value as string}
+                                  onChange={(e) =>
+                                    updateService(key, {
+                                      [field.key]: (e.target as HTMLInputElement).value,
+                                    })
+                                  }
+                                  placeholder={field.placeholder}
+                                  style={{
+                                    width: '100%',
+                                    padding: '10px 12px',
+                                    borderRadius: 8,
+                                    border: '1px solid rgba(255,255,255,0.2)',
+                                    background: 'rgba(0,0,0,0.35)',
+                                    color: 'white',
+                                    fontSize: 13,
+                                  }}
+                                />
+                                {isApiKey && (
+                                  <button
+                                    type="button"
+                                    onClick={() => setRevealApiKey((prev) => !prev)}
+                                    style={{
+                                      position: 'absolute',
+                                      right: 10,
+                                      top: '50%',
+                                      transform: 'translateY(-50%)',
+                                      background: 'transparent',
+                                      border: 'none',
+                                      color: 'rgba(255,255,255,0.7)',
+                                      cursor: 'pointer',
+                                      fontSize: 12,
+                                    }}
+                                  >
+                                    {revealApiKey ? 'Hide' : 'Show'}
+                                  </button>
+                                )}
+                              </div>
+                              {field.helper && (
+                                <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.5)', marginTop: 4 }}>
+                                  {field.helper}
+                                </div>
+                              )}
+                              {defaultBase && (
+                                <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.45)', marginTop: 4 }}>
+                                  Clear to restore default: {defaultBase}
+                                </div>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.75)' }}>
+              Configure the language models powering the AI Navigator. Ollama is attempted first; if
+              unavailable, OpenRouter will proxy x-ai/grok-4-fast:free.
+            </div>
+            <div
+              style={{
+                padding: 16,
+                borderRadius: 12,
+                border: '1px solid rgba(255,255,255,0.1)',
+                background: 'rgba(255,255,255,0.03)',
+              }}
+            >
+              <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 6 }}>Ollama</div>
+              <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', marginBottom: 10 }}>
+                Runs locally on the specified host. Ensure the model name exists within your Ollama instance.
+              </div>
+              <label
+                style={{ fontSize: 12, display: 'block', color: 'rgba(255,255,255,0.75)', marginBottom: 4 }}
+              >
+                Base URL
+              </label>
+              <input
+                type="text"
+                value={services.ollama.baseUrl}
+                onChange={(e) => updateService('ollama', { baseUrl: (e.target as HTMLInputElement).value })}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: '1px solid rgba(255,255,255,0.2)',
+                  background: 'rgba(0,0,0,0.35)',
+                  color: 'white',
+                  fontSize: 13,
+                }}
+              />
+              <label
+                style={{
+                  fontSize: 12,
+                  display: 'block',
+                  color: 'rgba(255,255,255,0.75)',
+                  margin: '10px 0 4px',
+                }}
+              >
+                Model
+              </label>
+              <input
+                type="text"
+                value={services.ollama.model ?? ''}
+                onChange={(e) => updateService('ollama', { model: (e.target as HTMLInputElement).value })}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: '1px solid rgba(255,255,255,0.2)',
+                  background: 'rgba(0,0,0,0.35)',
+                  color: 'white',
+                  fontSize: 13,
+                }}
+              />
+            </div>
+
+            <div
+              style={{
+                padding: 16,
+                borderRadius: 12,
+                border: '1px solid rgba(255,255,255,0.1)',
+                background: 'rgba(255,255,255,0.03)',
+              }}
+            >
+              <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 6 }}>OpenRouter</div>
+              <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', marginBottom: 10 }}>
+                Provide an API key for hosted fallback. Data is sent directly to OpenRouter.
+              </div>
+              <label
+                style={{ fontSize: 12, display: 'block', color: 'rgba(255,255,255,0.75)', marginBottom: 4 }}
+              >
+                Base URL
+              </label>
+              <input
+                type="text"
+                value={services.openRouter.baseUrl}
+                onChange={(e) =>
+                  updateService('openRouter', { baseUrl: (e.target as HTMLInputElement).value })
+                }
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: '1px solid rgba(255,255,255,0.2)',
+                  background: 'rgba(0,0,0,0.35)',
+                  color: 'white',
+                  fontSize: 13,
+                }}
+              />
+              <label
+                style={{
+                  fontSize: 12,
+                  display: 'block',
+                  color: 'rgba(255,255,255,0.75)',
+                  margin: '10px 0 4px',
+                }}
+              >
+                API Key
+              </label>
+              <div style={{ position: 'relative' }}>
+                <input
+                  type={revealApiKey ? 'text' : 'password'}
+                  value={services.openRouter.apiKey ?? ''}
+                  onChange={(e) =>
+                    updateService('openRouter', { apiKey: (e.target as HTMLInputElement).value })
+                  }
+                  style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    borderRadius: 8,
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    background: 'rgba(0,0,0,0.35)',
+                    color: 'white',
+                    fontSize: 13,
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setRevealApiKey((prev) => !prev)}
+                  style={{
+                    position: 'absolute',
+                    right: 10,
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                    background: 'transparent',
+                    border: 'none',
+                    color: 'rgba(255,255,255,0.7)',
+                    cursor: 'pointer',
+                    fontSize: 12,
+                  }}
+                >
+                  {revealApiKey ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              <label
+                style={{
+                  fontSize: 12,
+                  display: 'block',
+                  color: 'rgba(255,255,255,0.75)',
+                  margin: '10px 0 4px',
+                }}
+              >
+                Model
+              </label>
+              <input
+                type="text"
+                value={services.openRouter.model ?? ''}
+                onChange={(e) => updateService('openRouter', { model: (e.target as HTMLInputElement).value })}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: '1px solid rgba(255,255,255,0.2)',
+                  background: 'rgba(0,0,0,0.35)',
+                  color: 'white',
+                  fontSize: 13,
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{ padding: 20, borderTop: '1px solid rgba(255,255,255,0.1)', background: 'rgba(0,0,0,0.4)' }}
+      >
+        <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', marginBottom: 10 }}>
+          Settings persist locally in your browser storage. Use the reset button to return to 192.168.0.71
+          defaults.
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <button
+            onClick={resetToDefaults}
+            style={{
+              background: 'rgba(255, 107, 107, 0.15)',
+              border: '1px solid rgba(255,107,107,0.4)',
+              color: '#FF6B6B',
+              borderRadius: 8,
+              padding: '8px 12px',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}
+          >
+            Reset to defaults
+          </button>
+          <button
+            onClick={onClose}
+            style={{
+              background: '#4ECDC4',
+              border: 'none',
+              color: '#0B1F1E',
+              borderRadius: 8,
+              padding: '8px 16px',
+              cursor: 'pointer',
+              fontWeight: 600,
+              fontSize: 12,
+            }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ConnectionSettingsDrawer

--- a/src/components/Scene3D.tsx
+++ b/src/components/Scene3D.tsx
@@ -2,7 +2,18 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useThree, useFrame } from '@react-three/fiber'
 import { TrackballControls } from '@react-three/drei'
-import useStore from '../state/store'
+import type { Group } from 'three'
+import type { TrackballControls as TrackballControlsImpl } from 'three-stdlib'
+import useStore, {
+  useEntities,
+  useRelationships,
+  useEntityPositions,
+  useLayout,
+  useHighlightEntities,
+  useTargetEntity,
+  useXRayMode,
+  useResetCam,
+} from '../state/store'
 import { animate } from 'framer-motion'
 import KnowledgeNode from './KnowledgeNode'
 
@@ -25,19 +36,19 @@ function RelationshipLine({ relationship, entityPositions }: { relationship: { s
 }
 
 export default function Scene3D(): JSX.Element {
-  const entities = useStore.use.entities()
-  const relationships = useStore.use.relationships()
-  const entityPositions = useStore.use.entityPositions()
-  const layout = useStore.use.layout()
-  const highlightEntities = useStore.use.highlightEntities()
-  const targetEntity = useStore.use.targetEntity()
-  const xRayMode = useStore.use.xRayMode()
-  const resetCam = useStore.use.resetCam()
+  const entities = useEntities()
+  const relationships = useRelationships()
+  const entityPositions = useEntityPositions()
+  const layout = useLayout()
+  const highlightEntities = useHighlightEntities()
+  const targetEntity = useTargetEntity()
+  const xRayMode = useXRayMode()
+  const resetCam = useResetCam()
   const { camera } = useThree()
-  const groupRef = useRef<any>()
-  const controlsRef = useRef<any>()
+  const groupRef = useRef<Group | null>(null)
+  const controlsRef = useRef<TrackballControlsImpl | null>(null)
   const [isAutoRotating, setIsAutoRotating] = useState(false)
-  const inactivityTimerRef = useRef<any>(null)
+  const inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const rotationVelocityRef = useRef(0)
 
   const cameraDistance = 25
@@ -169,7 +180,7 @@ export default function Scene3D(): JSX.Element {
       <pointLight position={[-10, -10, -5]} intensity={0.5} />
 
       <TrackballControls
-        ref={controlsRef as any}
+        ref={controlsRef}
         onStart={() => handleInteractionStart()}
         onEnd={() => handleInteractionEnd()}
         minDistance={10}
@@ -193,7 +204,7 @@ export default function Scene3D(): JSX.Element {
         </group>
       )}
 
-      <group ref={groupRef as any}>
+      <group ref={groupRef}>
         {relationships.map((rel, idx) => (
           <RelationshipLine key={`${rel.source}-${rel.target}-${idx}`} relationship={rel} entityPositions={entityPositions} />
         ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useMemo, useState } from 'react'
-import useStore from '../state/store'
+import useStore, {
+  useIsSidebarOpen,
+  useEntities,
+  useHighlightEntities,
+  useTargetEntity,
+  useSearchQuery,
+  useEntityTypeFilter,
+} from '../state/store'
 import { analyzeEntity, followRelationship, setTargetEntity } from '../state/actions'
 
-function colorFor(type: ReturnType<typeof useStore> extends any ? string : string) {
+function colorFor(type: string) {
   const m: Record<string, string> = {
     PERSON: '#FF6B6B',
     ORGANIZATION: '#4ECDC4',
@@ -16,12 +23,12 @@ function colorFor(type: ReturnType<typeof useStore> extends any ? string : strin
 }
 
 export default function Sidebar(): JSX.Element | null {
-  const isOpen = useStore.use.isSidebarOpen()
-  const entities = useStore.use.entities()
-  const highlightEntities = useStore.use.highlightEntities()
-  const targetEntity = useStore.use.targetEntity()
-  const searchQuery = useStore.use.searchQuery()
-  const entityTypeFilter = useStore.use.entityTypeFilter()
+  const isOpen = useIsSidebarOpen()
+  const entities = useEntities()
+  const highlightEntities = useHighlightEntities()
+  const targetEntity = useTargetEntity()
+  const searchQuery = useSearchQuery()
+  const entityTypeFilter = useEntityTypeFilter()
   const getEntityConnections = (name: string) => useStore.getState().getEntityConnections(name)
 
   const [sortBy, setSortBy] = useState<'name' | 'type' | 'connections'>('name')

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -4,10 +4,10 @@ export type EnvConfig = {
 }
 
 // High-port default (per preference): 49160
+// When no persisted settings exist the settings store will fall back to this value.
 export function getEnvConfig(): EnvConfig {
   // Vite-style env access
   const fromVite = (import.meta as any)?.env?.VITE_HKG_MCP_BASE_URL as string | undefined
-  const base = fromVite || 'http://localhost:49160'
+  const base = fromVite || 'http://192.168.0.71:49160'
   return { HKG_MCP_BASE_URL: base.replace(/\/$/, '') }
 }
-

--- a/src/services/hkgLoader.ts
+++ b/src/services/hkgLoader.ts
@@ -1,11 +1,137 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Entity, Relationship } from '../types/knowledge'
 import { getEnvConfig } from '../config/env'
+import useSettingsStore, {
+  ConnectionMode,
+  getServiceConfigSnapshot,
+  MCP_DEFAULT,
+} from '../state/settingsStore'
 
-export type KnowledgeGraphResult = {
+export type KnowledgeGraphMetadata = {
+  source?: string
+  timestamp?: string
+  entity_count?: number
+  relationship_count?: number
+  connection_mode?: ConnectionMode
+  endpoint?: string
+  [key: string]: unknown
+}
+
+export type KnowledgeGraphResponse = {
   knowledge_graph: { entities: Entity[]; relationships: Relationship[] }
-  metadata: any
-} | null
+  metadata: KnowledgeGraphMetadata
+}
+
+export type KnowledgeGraphResult = KnowledgeGraphResponse | null
+
+type Neo4jLoadOptions = {
+  limit?: number
+  offset?: number
+  entityTypes?: string[]
+  searchQuery?: string
+  maxConnections?: number
+  centerEntity?: string | null
+}
+
+type RawNeo4jEntity = {
+  name?: string
+  entityType?: string
+  observations?: unknown
+  uuid?: string
+}
+
+type RawNeo4jRelationship = {
+  from?: string
+  to?: string
+  relationType?: string
+  uuid?: string
+}
+
+type RawNeo4jGraph = {
+  entities?: RawNeo4jEntity[]
+  relationships?: RawNeo4jRelationship[]
+  totalCount?: number
+}
+
+type RawQdrantMetadata = {
+  entities?: Entity[]
+  relationships?: Relationship[]
+  entity_name?: string
+  entity_type?: string
+  description?: string
+  uuid?: string
+}
+
+type RawQdrantResult = {
+  metadata?: RawQdrantMetadata
+  information?: string
+  id?: string
+}
+
+type RawPostgresLog = {
+  metadata?: {
+    knowledge_graph?: {
+      entities?: Entity[]
+      relationships?: Relationship[]
+      uuid?: string
+    }
+    uuid?: string
+  }
+}
+
+type VectorSearchResult = RawQdrantResult & { uuid?: string }
+type AuditSearchResult = RawPostgresLog & { uuid?: string }
+
+const ENTITY_TYPE_VALUES: ReadonlyArray<Entity['type']> = [
+  'CONCEPT',
+  'PERSON',
+  'ORGANIZATION',
+  'LOCATION',
+  'EVENT',
+  'OTHER',
+]
+
+function normalizeEntityType(value: unknown): Entity['type'] {
+  if (typeof value === 'string') {
+    const upper = value.toUpperCase()
+    if ((ENTITY_TYPE_VALUES as ReadonlyArray<string>).includes(upper)) {
+      return upper as Entity['type']
+    }
+  }
+  return 'OTHER'
+}
+
+function coerceDescription(observations: unknown, fallback: string): string {
+  if (Array.isArray(observations)) {
+    const parts = observations.filter((item): item is string => typeof item === 'string')
+    if (parts.length > 0) return parts.join('; ')
+  }
+  return fallback
+}
+
+function sanitizeBaseUrl(base?: string | null): string | null {
+  if (!base) return null
+  const trimmed = base.trim()
+  return trimmed ? trimmed.replace(/\/$/, '') : null
+}
+
+function basicAuthHeader(username?: string, password?: string): string | null {
+  if (!username || !password) return null
+  const value = `${username}:${password}`
+  try {
+    if (typeof btoa === 'function') return `Basic ${btoa(value)}`
+  } catch (_) {
+    // ignore and try Buffer fallback
+  }
+  try {
+    const maybeBuffer = (globalThis as { Buffer?: { from(value: string, encoding: string): { toString(enc: string): string } } })
+      .Buffer
+    if (maybeBuffer) return `Basic ${maybeBuffer.from(value, 'utf-8').toString('base64')}`
+  } catch (_) {
+    // no-op
+  }
+  return null
+}
 
 async function tryFetch(input: RequestInfo, init?: RequestInit, timeoutMs = 5000): Promise<Response> {
   const controller = new AbortController()
@@ -20,147 +146,296 @@ async function tryFetch(input: RequestInfo, init?: RequestInit, timeoutMs = 5000
 
 export async function findWorkingMCPServer(): Promise<string | null> {
   const { HKG_MCP_BASE_URL } = getEnvConfig()
-  const candidates = [HKG_MCP_BASE_URL, 'http://localhost:3000', 'http://localhost:8080', 'http://localhost:7860']
+  const settings = useSettingsStore.getState()
+  const defaults = [
+    MCP_DEFAULT,
+    'http://localhost:49160',
+    'http://localhost:3000',
+    'http://localhost:8080',
+    'http://localhost:7860',
+  ]
+  const candidates = [settings.getMCPBaseUrl(), HKG_MCP_BASE_URL, ...defaults]
+    .filter((url): url is string => !!url)
+    .map((url) => url.replace(/\/$/, ''))
+  const seen = new Set<string>()
   for (const url of candidates) {
+    if (seen.has(url)) continue
+    seen.add(url)
     try {
       const r = await tryFetch(`${url}/health`, { method: 'GET' }, 2000)
       if (r.ok) return url
     } catch (_) {
-      // continue
+      // continue searching
     }
   }
   return null
 }
 
-export async function loadFromNeo4j(options: {
-  limit?: number
-  offset?: number
-  entityTypes?: string[]
-  searchQuery?: string
-  maxConnections?: number
-  centerEntity?: string | null
-} = {}): Promise<KnowledgeGraphResult> {
+function mapNeo4jGraph(
+  graphData: RawNeo4jGraph,
+  options: Neo4jLoadOptions,
+  mode: ConnectionMode,
+  endpoint: string
+): KnowledgeGraphResult {
+  const entities: Entity[] = Array.isArray(graphData.entities)
+    ? graphData.entities.map((raw) => {
+        const name = typeof raw.name === 'string' ? raw.name : 'Unknown'
+        return {
+          name,
+          type: normalizeEntityType(raw.entityType),
+          description: coerceDescription(raw.observations, name),
+          uuid: typeof raw.uuid === 'string' ? raw.uuid : undefined,
+        }
+      })
+    : []
+
+  const relationships: Relationship[] = Array.isArray(graphData.relationships)
+    ? graphData.relationships
+        .map((raw) => ({
+          source: typeof raw.from === 'string' ? raw.from : '',
+          target: typeof raw.to === 'string' ? raw.to : '',
+          relationship: typeof raw.relationType === 'string' ? raw.relationType : 'RELATED_TO',
+          uuid: typeof raw.uuid === 'string' ? raw.uuid : undefined,
+        }))
+        .filter((rel) => rel.source && rel.target)
+    : []
+
+  return {
+    knowledge_graph: { entities, relationships },
+    metadata: {
+      source: 'neo4j',
+      timestamp: new Date().toISOString(),
+      entity_count: entities.length,
+      relationship_count: relationships.length,
+      query_params: options,
+      has_more: Boolean(options.limit) && entities.length === (options.limit ?? 0),
+      total_available: typeof graphData.totalCount === 'number' ? graphData.totalCount : entities.length,
+      connection_mode: mode,
+      endpoint,
+    },
+  }
+}
+
+export async function loadFromNeo4j(options: Neo4jLoadOptions = {}): Promise<KnowledgeGraphResult> {
+  const settings = useSettingsStore.getState()
+  const serviceConfig = getServiceConfigSnapshot('neo4j')
+  const perServiceBase = settings.mode === 'perService' ? sanitizeBaseUrl(serviceConfig.baseUrl) : null
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const auth = basicAuthHeader(serviceConfig.username, serviceConfig.password)
+  if (auth) headers.Authorization = auth
+  const payload = JSON.stringify(options)
+
+  if (perServiceBase) {
+    const endpoint = `${perServiceBase}/mcp/neo4j/read_graph`
+    try {
+      const resp = await tryFetch(endpoint, { method: 'POST', headers, body: payload }, 8000)
+      if (!resp.ok) throw new Error(`Neo4j request failed: ${resp.status}`)
+      const graphData = await resp.json()
+      return mapNeo4jGraph(graphData, options, 'perService', endpoint)
+    } catch (err) {
+      console.warn('Neo4j per-service fetch failed:', err)
+    }
+  }
+
   try {
     const base = await findWorkingMCPServer()
     if (!base) throw new Error('No MCP server available')
-    const resp = await tryFetch(`${base}/mcp/neo4j/read_graph`, {
+    const endpoint = `${base}/mcp/neo4j/read_graph`
+    const resp = await tryFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(options),
+      body: payload,
     })
     if (!resp.ok) throw new Error(`Neo4j request failed: ${resp.status}`)
     const graphData = await resp.json()
-    const entities: Entity[] = (graphData.entities || []).map((e: any) => ({
-      name: e.name,
-      type: e.entityType || 'OTHER',
-      description: Array.isArray(e.observations) ? e.observations.join('; ') : e.name,
-      uuid: e.uuid,
-    }))
-    const relationships: Relationship[] = (graphData.relationships || []).map((r: any) => ({
-      source: r.from,
-      target: r.to,
-      relationship: r.relationType,
-      uuid: r.uuid,
-    }))
-    return {
-      knowledge_graph: { entities, relationships },
-      metadata: {
-        source: 'neo4j',
-        timestamp: new Date().toISOString(),
-        entity_count: entities.length,
-        relationship_count: relationships.length,
-        query_params: options,
-        has_more: entities.length === (options.limit || 0),
-        total_available: graphData.totalCount || entities.length,
-      },
-    }
+    return mapNeo4jGraph(graphData, options, 'unified', endpoint)
   } catch (e) {
     console.error('Failed to load from Neo4j:', e)
     return null
   }
 }
 
-export async function loadFromQdrant(searchQuery = 'knowledge graph entities'): Promise<KnowledgeGraphResult> {
+export async function loadFromQdrant(
+  searchQuery = 'knowledge graph entities'
+): Promise<KnowledgeGraphResult> {
+  const settings = useSettingsStore.getState()
+  const serviceConfig = getServiceConfigSnapshot('qdrant')
+  const perServiceBase = settings.mode === 'perService' ? sanitizeBaseUrl(serviceConfig.baseUrl) : null
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (serviceConfig.apiKey) headers['api-key'] = serviceConfig.apiKey
+
+  if (perServiceBase) {
+    const endpoint = `${perServiceBase}/mcp/qdrant/find`
+    try {
+      const resp = await tryFetch(
+        endpoint,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ query: searchQuery }),
+        },
+        8000
+      )
+      if (!resp.ok) throw new Error(`Qdrant request failed: ${resp.status}`)
+      const data = (await resp.json()) as RawQdrantResult[]
+      return mapQdrantResults(data, searchQuery, 'perService', endpoint)
+    } catch (err) {
+      console.warn('Qdrant per-service fetch failed:', err)
+    }
+  }
+
   try {
     const base = await findWorkingMCPServer()
     if (!base) throw new Error('No MCP server available')
-    const resp = await tryFetch(`${base}/mcp/qdrant/find`, {
+    const endpoint = `${base}/mcp/qdrant/find`
+    const resp = await tryFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: searchQuery }),
     })
     if (!resp.ok) throw new Error(`Qdrant request failed: ${resp.status}`)
-    const data = await resp.json()
-    const entities: Entity[] = []
-    const relationships: Relationship[] = []
-    ;(data || []).forEach((result: any) => {
-      if (result?.metadata) {
-        if (Array.isArray(result.metadata.entities)) entities.push(...result.metadata.entities)
-        if (Array.isArray(result.metadata.relationships)) relationships.push(...result.metadata.relationships)
-        if (result.metadata.entity_name) {
-          entities.push({
-            name: result.metadata.entity_name,
-            type: result.metadata.entity_type || 'CONCEPT',
-            description: result.information || result.metadata.description || '',
-          })
-        }
-      }
-    })
-    return {
-      knowledge_graph: { entities, relationships },
-      metadata: {
-        source: 'qdrant',
-        search_query: searchQuery,
-        timestamp: new Date().toISOString(),
-        entity_count: entities.length,
-        relationship_count: relationships.length,
-      },
-    }
+    const data = (await resp.json()) as RawQdrantResult[]
+    return mapQdrantResults(data, searchQuery, 'unified', endpoint)
   } catch (e) {
     console.error('Failed to load from Qdrant:', e)
     return null
   }
 }
 
+function mapQdrantResults(
+  data: RawQdrantResult[] | undefined,
+  searchQuery: string,
+  mode: ConnectionMode,
+  endpoint: string
+): KnowledgeGraphResult {
+  const entities: Entity[] = []
+  const relationships: Relationship[] = []
+
+  ;(data ?? []).forEach((result) => {
+    const metadata = result.metadata
+    if (metadata) {
+      if (Array.isArray(metadata.entities)) {
+        entities.push(
+          ...metadata.entities.map((entity) => ({
+            ...entity,
+            vectorMatch: true,
+          }))
+        )
+      }
+      if (Array.isArray(metadata.relationships)) {
+        relationships.push(...metadata.relationships)
+      }
+      if (typeof metadata.entity_name === 'string') {
+        entities.push({
+          name: metadata.entity_name,
+          type: normalizeEntityType(metadata.entity_type),
+          description:
+            typeof result.information === 'string'
+              ? result.information
+              : typeof metadata.description === 'string'
+                ? metadata.description
+                : '',
+          uuid: typeof metadata.uuid === 'string' ? metadata.uuid : undefined,
+          vectorMatch: true,
+        })
+      }
+    }
+  })
+
+  return {
+    knowledge_graph: { entities, relationships },
+    metadata: {
+      source: 'qdrant',
+      search_query: searchQuery,
+      timestamp: new Date().toISOString(),
+      entity_count: entities.length,
+      relationship_count: relationships.length,
+      connection_mode: mode,
+      endpoint,
+    },
+  }
+}
+
 export async function loadFromPostgreSQL(): Promise<KnowledgeGraphResult> {
+  const settings = useSettingsStore.getState()
+  const serviceConfig = getServiceConfigSnapshot('postgres')
+  const perServiceBase = settings.mode === 'perService' ? sanitizeBaseUrl(serviceConfig.baseUrl) : null
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const auth = basicAuthHeader(serviceConfig.username, serviceConfig.password)
+  if (auth) headers.Authorization = auth
+  const body = JSON.stringify({
+    action: 'knowledge_graph_creation',
+    limit: 50,
+    startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  })
+
+  if (perServiceBase) {
+    const endpoint = `${perServiceBase}/mcp/postgres/query_audit_logs`
+    try {
+      const resp = await tryFetch(endpoint, { method: 'POST', headers, body }, 8000)
+      if (!resp.ok) throw new Error(`PostgreSQL request failed: ${resp.status}`)
+      const auditLogs = (await resp.json()) as RawPostgresLog[]
+      return mapPostgresResults(auditLogs, 'perService', endpoint)
+    } catch (err) {
+      console.warn('PostgreSQL per-service fetch failed:', err)
+    }
+  }
+
   try {
     const base = await findWorkingMCPServer()
     if (!base) throw new Error('No MCP server available')
-    const resp = await tryFetch(`${base}/mcp/postgres/query_audit_logs`, {
+    const endpoint = `${base}/mcp/postgres/query_audit_logs`
+    const resp = await tryFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        action: 'knowledge_graph_creation',
-        limit: 50,
-        startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
-      }),
+      body,
     })
     if (!resp.ok) throw new Error(`PostgreSQL request failed: ${resp.status}`)
-    const auditLogs = await resp.json()
-    const entities: Entity[] = []
-    const relationships: Relationship[] = []
-    ;(auditLogs || []).forEach((log: any) => {
-      const kg = log?.metadata?.knowledge_graph
-      if (kg?.entities) entities.push(...kg.entities)
-      if (kg?.relationships) relationships.push(...kg.relationships)
-    })
-    return {
-      knowledge_graph: { entities, relationships },
-      metadata: {
-        source: 'postgresql',
-        audit_entries: Array.isArray(auditLogs) ? auditLogs.length : 0,
-        timestamp: new Date().toISOString(),
-        entity_count: entities.length,
-        relationship_count: relationships.length,
-      },
-    }
+    const auditLogs = (await resp.json()) as RawPostgresLog[]
+    return mapPostgresResults(auditLogs, 'unified', endpoint)
   } catch (e) {
     console.error('Failed to load from PostgreSQL:', e)
     return null
   }
 }
 
-export async function loadFromHKG(dataSource: 'auto' | 'neo4j' | 'qdrant' | 'postgresql' = 'auto'): Promise<KnowledgeGraphResult> {
+function mapPostgresResults(
+  auditLogs: RawPostgresLog[] | undefined,
+  mode: ConnectionMode,
+  endpoint: string
+): KnowledgeGraphResult {
+  const entities: Entity[] = []
+  const relationships: Relationship[] = []
+
+  ;(auditLogs ?? []).forEach((log) => {
+    const knowledgeGraph = log.metadata?.knowledge_graph
+    if (knowledgeGraph) {
+      if (Array.isArray(knowledgeGraph.entities)) {
+        entities.push(...knowledgeGraph.entities)
+      }
+      if (Array.isArray(knowledgeGraph.relationships)) {
+        relationships.push(...knowledgeGraph.relationships)
+      }
+    }
+  })
+
+  return {
+    knowledge_graph: { entities, relationships },
+    metadata: {
+      source: 'postgresql',
+      audit_entries: Array.isArray(auditLogs) ? auditLogs.length : 0,
+      timestamp: new Date().toISOString(),
+      entity_count: entities.length,
+      relationship_count: relationships.length,
+      connection_mode: mode,
+      endpoint,
+    },
+  }
+}
+
+export async function loadFromHKG(
+  dataSource: 'auto' | 'neo4j' | 'qdrant' | 'postgresql' = 'auto'
+): Promise<KnowledgeGraphResult> {
   switch (dataSource) {
     case 'neo4j':
       return loadFromNeo4j()
@@ -178,25 +453,39 @@ export async function loadFromHKG(dataSource: 'auto' | 'neo4j' | 'qdrant' | 'pos
   }
 }
 
-export async function loadCenteredSubgraph(centerEntity: string, maxDepth = 2, maxNodes = 200): Promise<KnowledgeGraphResult> {
+export async function loadCenteredSubgraph(
+  centerEntity: string,
+  maxDepth = 2,
+  maxNodes = 200
+): Promise<KnowledgeGraphResult> {
   const result = await loadFromNeo4j({
     centerEntity,
     limit: maxNodes,
     maxConnections: Math.floor(maxNodes / 4),
   })
   if (result) {
-    ;(result as any).metadata.view_type = 'centered_subgraph'
-    ;(result as any).metadata.center_entity = centerEntity
-    ;(result as any).metadata.max_depth = maxDepth
+    result.metadata = {
+      ...result.metadata,
+      view_type: 'centered_subgraph',
+      center_entity: centerEntity,
+      max_depth: maxDepth,
+    }
   }
   return result
 }
 
-export async function loadByEntityType(entityType: Entity['type'], limit = 300, offset = 0): Promise<KnowledgeGraphResult> {
+export async function loadByEntityType(
+  entityType: Entity['type'],
+  limit = 300,
+  offset = 0
+): Promise<KnowledgeGraphResult> {
   const result = await loadFromNeo4j({ entityTypes: [entityType], limit, offset, maxConnections: 30 })
   if (result) {
-    ;(result as any).metadata.view_type = 'entity_type_view'
-    ;(result as any).metadata.filtered_type = entityType
+    result.metadata = {
+      ...result.metadata,
+      view_type: 'entity_type_view',
+      filtered_type: entityType,
+    }
   }
   return result
 }
@@ -204,19 +493,25 @@ export async function loadByEntityType(entityType: Entity['type'], limit = 300, 
 export async function loadSearchResults(searchQuery: string, limit = 100): Promise<KnowledgeGraphResult> {
   const result = await loadFromNeo4j({ searchQuery, limit, maxConnections: 20 })
   if (result) {
-    ;(result as any).metadata.view_type = 'search_results'
-    ;(result as any).metadata.search_query = searchQuery
+    result.metadata = {
+      ...result.metadata,
+      view_type: 'search_results',
+      search_query: searchQuery,
+    }
   }
   return result
 }
 
-export async function searchShardedHKG(searchTopic: string, options: {
-  maxResultsPerShard?: number
-  preferVectorSearch?: boolean
-  includeAuditTrail?: boolean
-  coordinateByUUID?: boolean
-  shardTimeout?: number
-} = {}): Promise<KnowledgeGraphResult> {
+export async function searchShardedHKG(
+  searchTopic: string,
+  options: {
+    maxResultsPerShard?: number
+    preferVectorSearch?: boolean
+    includeAuditTrail?: boolean
+    coordinateByUUID?: boolean
+    shardTimeout?: number
+  } = {}
+ ): Promise<KnowledgeGraphResult> {
   const {
     maxResultsPerShard = 50,
     preferVectorSearch = true,
@@ -229,8 +524,8 @@ export async function searchShardedHKG(searchTopic: string, options: {
 
   const vectorUUIDs = new Set<string>()
   const auditUUIDs = new Set<string>()
-  let vectorResults: any[] = []
-  let auditResults: any[] = []
+  let vectorResults: VectorSearchResult[] = []
+  let auditResults: AuditSearchResult[] = []
 
   if (preferVectorSearch) {
     try {
@@ -240,12 +535,26 @@ export async function searchShardedHKG(searchTopic: string, options: {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ query: searchTopic, limit: maxResultsPerShard, similarity_threshold: 0.7 }),
         }),
-        new Promise<Response>((_, reject) => setTimeout(() => reject(new Error('Qdrant timeout')), shardTimeout)),
+        new Promise<Response>((_, reject) =>
+          setTimeout(() => reject(new Error('Qdrant timeout')), shardTimeout)
+        ),
       ])
       if (qRes.ok) {
-        const qData = await qRes.json()
-        vectorResults = qData.map((r: any) => ({ uuid: r?.metadata?.uuid || r?.id, ...r }))
-        vectorResults.forEach((r) => r.uuid && vectorUUIDs.add(r.uuid))
+        const qData = (await qRes.json()) as RawQdrantResult[]
+        vectorResults = qData
+          .map<VectorSearchResult>((entry) => ({
+            ...entry,
+            uuid:
+              typeof entry.metadata?.uuid === 'string'
+                ? entry.metadata.uuid
+                : typeof entry.id === 'string'
+                  ? entry.id
+                  : undefined,
+          }))
+          .filter((result): result is VectorSearchResult => typeof result.uuid === 'string')
+        vectorResults.forEach((result) => {
+          if (result.uuid) vectorUUIDs.add(result.uuid)
+        })
       }
     } catch (e) {
       console.warn('Qdrant vector search failed:', (e as Error).message)
@@ -258,16 +567,33 @@ export async function searchShardedHKG(searchTopic: string, options: {
         tryFetch(`${base}/mcp/postgres/query_audit_logs`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ action: 'knowledge_graph_creation', content: searchTopic, limit: maxResultsPerShard, startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString() }),
+          body: JSON.stringify({
+            action: 'knowledge_graph_creation',
+            content: searchTopic,
+            limit: maxResultsPerShard,
+            startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+          }),
         }),
-        new Promise<Response>((_, reject) => setTimeout(() => reject(new Error('PostgreSQL timeout')), shardTimeout)),
+        new Promise<Response>((_, reject) =>
+          setTimeout(() => reject(new Error('PostgreSQL timeout')), shardTimeout)
+        ),
       ])
       if (aRes.ok) {
-        const aData = await aRes.json()
+        const aData = (await aRes.json()) as RawPostgresLog[]
         auditResults = aData
-          .map((log: any) => ({ uuid: log?.metadata?.uuid || log?.metadata?.knowledge_graph?.uuid, ...log }))
-          .filter((r: any) => r.uuid)
-        auditResults.forEach((r: any) => auditUUIDs.add(r.uuid))
+          .map<AuditSearchResult>((log) => ({
+            ...log,
+            uuid:
+              typeof log.metadata?.uuid === 'string'
+                ? log.metadata.uuid
+                : typeof log.metadata?.knowledge_graph?.uuid === 'string'
+                  ? log.metadata.knowledge_graph.uuid
+                  : undefined,
+          }))
+          .filter((log): log is AuditSearchResult => typeof log.uuid === 'string')
+        auditResults.forEach((log) => {
+          if (log.uuid) auditUUIDs.add(log.uuid)
+        })
       }
     } catch (e) {
       console.warn('PostgreSQL audit search failed:', (e as Error).message)
@@ -278,31 +604,45 @@ export async function searchShardedHKG(searchTopic: string, options: {
   let coordinatedRelationships: Relationship[] = []
 
   if (coordinateByUUID) {
-    const uuids = [...new Set([...vectorUUIDs, ...auditUUIDs])]
+    const uuids = Array.from(new Set<string>([...vectorUUIDs.values(), ...auditUUIDs.values()]))
     if (uuids.length > 0) {
       try {
         const nRes = await tryFetch(`${base}/mcp/neo4j/search_nodes`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ query: searchTopic, uuids, include_connected: true, max_depth: 2, limit: maxResultsPerShard * 2 }),
+          body: JSON.stringify({
+            query: searchTopic,
+            uuids,
+            include_connected: true,
+            max_depth: 2,
+            limit: maxResultsPerShard * 2,
+          }),
         })
         if (nRes.ok) {
-          const nData = await nRes.json()
-          coordinatedEntities = (nData.entities || []).map((e: any) => ({
-            uuid: e.uuid,
-            name: e.name,
-            type: e.entityType || 'OTHER',
-            description: Array.isArray(e.observations) ? e.observations.join('; ') : e.name,
-            searchRelevance: uuids.includes(e.uuid) ? 'uuid_coordinated' : 'connected',
-            vectorMatch: vectorUUIDs.has(e.uuid),
-            auditMatch: auditUUIDs.has(e.uuid),
-          }))
-          coordinatedRelationships = (nData.relationships || []).map((r: any) => ({
-            source: r.from,
-            target: r.to,
-            relationship: r.relationType,
-            uuid: r.uuid,
-          }))
+          const nData = (await nRes.json()) as RawNeo4jGraph
+          const rawEntities = Array.isArray(nData.entities) ? nData.entities : []
+          coordinatedEntities = rawEntities.map((raw) => {
+            const name = typeof raw.name === 'string' ? raw.name : 'Unknown'
+            const uuid = typeof raw.uuid === 'string' ? raw.uuid : undefined
+            return {
+              name,
+              type: normalizeEntityType(raw.entityType),
+              description: coerceDescription(raw.observations, name),
+              uuid,
+              searchRelevance: uuid && uuids.includes(uuid) ? 'uuid_coordinated' : 'connected',
+              vectorMatch: uuid ? vectorUUIDs.has(uuid) : false,
+              auditMatch: uuid ? auditUUIDs.has(uuid) : false,
+            }
+          })
+          const rawRelationships = Array.isArray(nData.relationships) ? nData.relationships : []
+          coordinatedRelationships = rawRelationships
+            .map((raw) => ({
+              source: typeof raw.from === 'string' ? raw.from : '',
+              target: typeof raw.to === 'string' ? raw.to : '',
+              relationship: typeof raw.relationType === 'string' ? raw.relationType : 'RELATED_TO',
+              uuid: typeof raw.uuid === 'string' ? raw.uuid : undefined,
+            }))
+            .filter((rel) => rel.source && rel.target)
         }
       } catch (e) {
         console.warn('Neo4j coordination failed:', (e as Error).message)
@@ -318,16 +658,19 @@ export async function searchShardedHKG(searchTopic: string, options: {
         body: JSON.stringify({ query: searchTopic, limit: maxResultsPerShard }),
       })
       if (fb.ok) {
-        const fData = await fb.json()
-        const fallbackEntities: Entity[] = (fData.entities || []).map((e: any) => ({
-          uuid: e.uuid,
-          name: e.name,
-          type: e.entityType || 'OTHER',
-          description: Array.isArray(e.observations) ? e.observations.join('; ') : e.name,
-          searchRelevance: 'text_search',
-        }))
-        const known = new Set(coordinatedEntities.map((e) => e.uuid))
-        coordinatedEntities.push(...fallbackEntities.filter((e) => !e.uuid || !known.has(e.uuid)))
+        const fData = (await fb.json()) as RawNeo4jGraph
+        const fallbackEntities: Entity[] = (Array.isArray(fData.entities) ? fData.entities : []).map((raw) => {
+          const name = typeof raw.name === 'string' ? raw.name : 'Unknown'
+          return {
+            uuid: typeof raw.uuid === 'string' ? raw.uuid : undefined,
+            name,
+            type: normalizeEntityType(raw.entityType),
+            description: coerceDescription(raw.observations, name),
+            searchRelevance: 'text_search',
+          }
+        })
+        const known = new Set(coordinatedEntities.map((e) => e.uuid).filter((id): id is string => Boolean(id)))
+        coordinatedEntities.push(...fallbackEntities.filter((entity) => !entity.uuid || !known.has(entity.uuid)))
       }
     } catch (e) {
       console.warn('Fallback Neo4j search failed:', (e as Error).message)
@@ -341,11 +684,20 @@ export async function searchShardedHKG(searchTopic: string, options: {
       search_topic: searchTopic,
       timestamp: new Date().toISOString(),
       view_type: 'sharded_search_results',
+      entity_count: coordinatedEntities.length,
+      relationship_count: coordinatedRelationships.length,
+      vector_results: vectorResults.length,
+      audit_results: auditResults.length,
     },
   }
 }
-
-export async function initializeHKG(options: { maxInitialNodes?: number; preferredTypes?: Entity['type'][]; source?: 'auto' | 'neo4j' | 'qdrant' | 'postgresql' } = {}): Promise<KnowledgeGraphResult> {
+export async function initializeHKG(
+  options: {
+    maxInitialNodes?: number
+    preferredTypes?: Entity['type'][]
+    source?: 'auto' | 'neo4j' | 'qdrant' | 'postgresql'
+  } = {}
+): Promise<KnowledgeGraphResult> {
   const { maxInitialNodes = 200, preferredTypes = ['CONCEPT'], source = 'auto' } = options
   let data: KnowledgeGraphResult = null
   if (preferredTypes.length > 0) {
@@ -356,4 +708,3 @@ export async function initializeHKG(options: { maxInitialNodes?: number; preferr
   }
   return data
 }
-

--- a/src/services/jsonGraphLoader.ts
+++ b/src/services/jsonGraphLoader.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { KnowledgeGraphResult } from './hkgLoader'
+import type { Entity, Relationship } from '../types/knowledge'
+
+const ENTITY_TYPE_OPTIONS: ReadonlyArray<Entity['type']> = [
+  'CONCEPT',
+  'PERSON',
+  'ORGANIZATION',
+  'LOCATION',
+  'EVENT',
+  'OTHER',
+]
+
+const SEARCH_RELEVANCE_VALUES = new Set<Entity['searchRelevance']>([
+  'uuid_coordinated',
+  'vector_semantic',
+  'audit_activity',
+  'text_search',
+])
+
+function coerceEntity(input: unknown, index: number): Entity {
+  if (!input || typeof input !== 'object') throw new Error(`Entity at index ${index} is not an object`)
+  const record = input as Record<string, unknown>
+  const rawName = record.name ?? record.title ?? ''
+  const name = typeof rawName === 'string' ? rawName.trim() : String(rawName).trim()
+  if (!name) throw new Error(`Entity at index ${index} is missing a name`)
+  const rawType = record.type ?? record.entityType ?? 'CONCEPT'
+  const typeCandidate = typeof rawType === 'string' ? rawType.toUpperCase() : String(rawType).toUpperCase()
+  const entityType = ENTITY_TYPE_OPTIONS.includes(typeCandidate as Entity['type'])
+    ? (typeCandidate as Entity['type'])
+    : 'OTHER'
+  const description = Array.isArray(record.observations)
+    ? record.observations.filter((item): item is string => typeof item === 'string').join('; ')
+    : typeof record.description === 'string'
+      ? record.description
+      : undefined
+  const entity: Entity = { name, type: entityType, description }
+  if (typeof record.uuid === 'string') entity.uuid = record.uuid
+  if (typeof record.searchRelevance === 'string' && SEARCH_RELEVANCE_VALUES.has(record.searchRelevance as Entity['searchRelevance'])) {
+    entity.searchRelevance = record.searchRelevance as Entity['searchRelevance']
+  }
+  if (typeof record.vectorMatch === 'boolean') entity.vectorMatch = record.vectorMatch
+  if (typeof record.auditMatch === 'boolean') entity.auditMatch = record.auditMatch
+  if (record.spatial_media && typeof record.spatial_media === 'object') {
+    entity.spatial_media = record.spatial_media as Entity['spatial_media']
+  }
+  return entity
+}
+
+function coerceRelationship(input: unknown, index: number): Relationship {
+  if (!input || typeof input !== 'object') throw new Error(`Relationship at index ${index} is not an object`)
+  const record = input as Record<string, unknown>
+  const source = typeof record.source === 'string' ? record.source : typeof record.from === 'string' ? record.from : ''
+  const target = typeof record.target === 'string' ? record.target : typeof record.to === 'string' ? record.to : ''
+  if (!source.trim() || !target.trim()) {
+    throw new Error(`Relationship at index ${index} must include source and target`)
+  }
+  const rawRelationship = record.relationship ?? record.type ?? record.label ?? 'RELATED_TO'
+  const relationship = typeof rawRelationship === 'string' ? rawRelationship : String(rawRelationship)
+  const rel: Relationship = { source: source.trim(), target: target.trim(), relationship }
+  if (typeof record.uuid === 'string') rel.uuid = record.uuid
+  return rel
+}
+
+export function parseKnowledgeGraphJson(raw: unknown): KnowledgeGraphResult {
+  if (!raw || typeof raw !== 'object') throw new Error('Knowledge graph JSON must be an object')
+  const container = raw as Record<string, unknown>
+  const maybeGraph = (container.knowledge_graph as Record<string, unknown> | undefined) ?? container
+  const entitiesRaw = maybeGraph.entities ?? []
+  const relationshipsRaw = maybeGraph.relationships ?? []
+  if (!Array.isArray(entitiesRaw)) throw new Error('knowledge_graph.entities must be an array')
+  if (!Array.isArray(relationshipsRaw)) throw new Error('knowledge_graph.relationships must be an array')
+
+  const entities = entitiesRaw.map(coerceEntity)
+  const relationships = relationshipsRaw.map(coerceRelationship)
+
+  const timestamp = new Date().toISOString()
+  return {
+    knowledge_graph: { entities, relationships },
+    metadata: {
+      source: 'json_upload',
+      imported_at: timestamp,
+      timestamp,
+      entity_count: entities.length,
+      relationship_count: relationships.length,
+    },
+  }
+}
+
+export async function loadGraphFromJsonFile(file: File): Promise<KnowledgeGraphResult> {
+  const text = await file.text()
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (err) {
+    throw new Error(`Invalid JSON: ${(err as Error).message}`)
+  }
+  const result = parseKnowledgeGraphJson(parsed)
+  const timestamp = new Date().toISOString()
+  const endpoint = `file://${encodeURIComponent(file.name)}`
+  result.metadata = {
+    connection_mode: 'file_upload',
+    endpoint,
+    ...result.metadata,
+    source: result.metadata?.source ?? 'json_upload',
+    imported_at: result.metadata?.imported_at ?? timestamp,
+    timestamp: result.metadata?.timestamp ?? timestamp,
+    source_file_name: file.name,
+    source_file_size: file.size,
+    source_file_last_modified: file.lastModified,
+  }
+  return result
+}

--- a/src/state/actions.ts
+++ b/src/state/actions.ts
@@ -104,7 +104,7 @@ export const followRelationship = (relationshipType: string, fromEntity: string,
 // Knowledge graph loading
 export const loadKnowledgeGraphData = (payload: {
   knowledge_graph: { entities: Entity[]; relationships: Relationship[] }
-  metadata?: any
+  metadata?: Record<string, unknown>
 }) => {
   const s = useStore.getState()
   s.setFetching(true)

--- a/src/state/settingsStore.ts
+++ b/src/state/settingsStore.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { getEnvConfig } from '../config/env'
+
+export type ConnectionMode = 'unified' | 'perService'
+
+export type EndpointAuth = {
+  username?: string
+  password?: string
+  apiKey?: string
+  model?: string
+}
+
+export type EndpointConfig = {
+  baseUrl: string
+} & EndpointAuth
+
+export type ServiceKey = 'neo4j' | 'qdrant' | 'postgres' | 'ollama' | 'openRouter'
+
+type SettingsState = {
+  mode: ConnectionMode
+  unified: {
+    baseUrl: string
+  }
+  services: Record<ServiceKey, EndpointConfig>
+  setMode: (mode: ConnectionMode) => void
+  updateUnifiedBaseUrl: (baseUrl: string) => void
+  updateService: (key: ServiceKey, patch: Partial<EndpointConfig>) => void
+  resetToDefaults: () => void
+  getMCPBaseUrl: () => string
+  getServiceConfig: (key: ServiceKey) => EndpointConfig
+}
+
+export const MCP_DEFAULT = 'http://192.168.0.71:49160'
+
+export const DEFAULT_SERVICE_ENDPOINTS: Record<ServiceKey, string> = {
+  neo4j: 'http://192.168.0.71:7474',
+  qdrant: 'http://192.168.0.71:6333',
+  postgres: 'postgresql://192.168.0.71:5432',
+  ollama: 'http://192.168.0.71:11434',
+  openRouter: 'https://openrouter.ai/api/v1',
+}
+
+const DEFAULT_SERVICE_CONFIGS: Record<ServiceKey, EndpointConfig> = {
+  neo4j: {
+    baseUrl: DEFAULT_SERVICE_ENDPOINTS.neo4j,
+    username: '',
+    password: '',
+  },
+  qdrant: {
+    baseUrl: DEFAULT_SERVICE_ENDPOINTS.qdrant,
+    apiKey: '',
+  },
+  postgres: {
+    baseUrl: DEFAULT_SERVICE_ENDPOINTS.postgres,
+    username: '',
+    password: '',
+  },
+  ollama: {
+    baseUrl: DEFAULT_SERVICE_ENDPOINTS.ollama,
+    model: 'llama3.1',
+  },
+  openRouter: {
+    baseUrl: DEFAULT_SERVICE_ENDPOINTS.openRouter,
+    apiKey: '',
+    model: 'openrouter/x-ai/grok-4-fast:free',
+  },
+}
+
+function cloneDefaultServiceConfig(key: ServiceKey): EndpointConfig {
+  const config = DEFAULT_SERVICE_CONFIGS[key]
+  return { ...config }
+}
+
+function sanitizeBaseUrl(base?: string | null): string | null {
+  if (typeof base !== 'string') return null
+  const trimmed = base.trim()
+  if (!trimmed) return null
+  return trimmed.replace(/\/$/, '')
+}
+
+function sanitizeAuthValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+const DEFAULTS: Pick<SettingsState, 'mode' | 'unified' | 'services'> = {
+  mode: 'unified',
+  unified: {
+    baseUrl: MCP_DEFAULT,
+  },
+  services: {
+    neo4j: cloneDefaultServiceConfig('neo4j'),
+    qdrant: cloneDefaultServiceConfig('qdrant'),
+    postgres: cloneDefaultServiceConfig('postgres'),
+    ollama: cloneDefaultServiceConfig('ollama'),
+    openRouter: cloneDefaultServiceConfig('openRouter'),
+  },
+}
+
+const storage = typeof window !== 'undefined' ? createJSONStorage(() => window.localStorage) : undefined
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set, get) => ({
+      ...DEFAULTS,
+      setMode: (mode) => set({ mode }),
+      updateUnifiedBaseUrl: (baseUrl) => {
+        const sanitized = sanitizeBaseUrl(baseUrl) ?? MCP_DEFAULT
+        set({ unified: { baseUrl: sanitized } })
+      },
+      updateService: (key, patch) => {
+        set((state) => {
+          const current = state.services[key] ?? cloneDefaultServiceConfig(key)
+          const defaults = cloneDefaultServiceConfig(key)
+          const next: EndpointConfig = { ...defaults, ...current }
+
+          if (Object.prototype.hasOwnProperty.call(patch, 'baseUrl')) {
+            const candidate = sanitizeBaseUrl(patch.baseUrl)
+            next.baseUrl = candidate ?? defaults.baseUrl
+          }
+
+          if (Object.prototype.hasOwnProperty.call(patch, 'username')) {
+            next.username = sanitizeAuthValue(patch.username) ?? ''
+          }
+          if (Object.prototype.hasOwnProperty.call(patch, 'password')) {
+            next.password = sanitizeAuthValue(patch.password) ?? ''
+          }
+          if (Object.prototype.hasOwnProperty.call(patch, 'apiKey')) {
+            next.apiKey = sanitizeAuthValue(patch.apiKey)
+          }
+          if (Object.prototype.hasOwnProperty.call(patch, 'model')) {
+            const sanitizedModel = sanitizeAuthValue(patch.model)
+            next.model = sanitizedModel ?? defaults.model
+          }
+
+          return {
+            services: {
+              ...state.services,
+              [key]: next,
+            },
+          }
+        })
+      },
+      resetToDefaults: () =>
+        set({
+          mode: DEFAULTS.mode,
+          unified: { ...DEFAULTS.unified },
+          services: {
+            neo4j: cloneDefaultServiceConfig('neo4j'),
+            qdrant: cloneDefaultServiceConfig('qdrant'),
+            postgres: cloneDefaultServiceConfig('postgres'),
+            ollama: cloneDefaultServiceConfig('ollama'),
+            openRouter: cloneDefaultServiceConfig('openRouter'),
+          },
+        }),
+      getMCPBaseUrl: () => {
+        const base = sanitizeBaseUrl(get().unified.baseUrl)
+        if (base) return base
+        const envBase = sanitizeBaseUrl(getEnvConfig().HKG_MCP_BASE_URL)
+        return envBase ?? MCP_DEFAULT
+      },
+      getServiceConfig: (key) => {
+        const svc = get().services[key]
+        const defaults = cloneDefaultServiceConfig(key)
+        const sanitizedBase = sanitizeBaseUrl(svc?.baseUrl)
+        return {
+          ...defaults,
+          ...svc,
+          baseUrl: sanitizedBase ?? defaults.baseUrl,
+        }
+      },
+    }),
+    {
+      name: 'kg3dnav-settings',
+      storage,
+      version: 1,
+      partialize: (state) => ({
+        mode: state.mode,
+        unified: state.unified,
+        services: state.services,
+      }),
+    }
+  )
+)
+
+export const useSettingsMode = (): ConnectionMode => useSettingsStore((s) => s.mode)
+export const useUnifiedBaseUrl = (): string => useSettingsStore((s) => s.unified.baseUrl)
+export const useServiceMap = (): Record<ServiceKey, EndpointConfig> => useSettingsStore((s) => s.services)
+
+export const getServiceConfigSnapshot = (key: ServiceKey): EndpointConfig =>
+  useSettingsStore.getState().getServiceConfig(key)
+
+export default useSettingsStore

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -62,7 +62,12 @@ export interface AppState {
   getEntityConnections: (name: string) => Relationship[]
 
   // Bulk ops
-  loadKnowledgeGraph: (payload: { knowledge_graph: { entities: Entity[]; relationships: Relationship[] }; metadata?: any }) => void
+  loadKnowledgeGraph: (
+    payload: {
+      knowledge_graph: { entities: Entity[]; relationships: Relationship[] }
+      metadata?: Record<string, unknown>
+    }
+  ) => void
   generateEntityPositions: () => void
 }
 
@@ -161,27 +166,45 @@ export const useStore = create<AppState>()(
   }))
 )
 
-// Convenience selector bundle mirroring prior pattern
-;(useStore as any).use = {
-  entities: () => useStore((s) => s.entities),
-  relationships: () => useStore((s) => s.relationships),
-  entityPositions: () => useStore((s) => s.entityPositions),
-  layout: () => useStore((s) => s.layout),
-  highlightEntities: () => useStore((s) => s.highlightEntities),
-  xRayMode: () => useStore((s) => s.xRayMode),
-  isSidebarOpen: () => useStore((s) => s.isSidebarOpen),
-  caption: () => useStore((s) => s.caption),
-  isFetching: () => useStore((s) => s.isFetching),
-  entityTypeFilter: () => useStore((s) => s.entityTypeFilter),
-  resetCam: () => useStore((s) => s.resetCam),
-  targetEntity: () => useStore((s) => s.targetEntity),
-  searchQuery: () => useStore((s) => s.searchQuery),
-  richMediaMode: () => useStore((s) => s.richMediaMode),
-  activeScene: () => useStore((s) => s.activeScene),
-  selectedRelationships: () => useStore((s) => s.selectedRelationships),
-  knowledgeGraphId: () => useStore((s) => s.knowledgeGraphId),
-  processingMethod: () => useStore((s) => s.processingMethod),
+type StoreWithSelectors = typeof useStore & {
+  useEntities: () => Entity[]
+  useRelationships: () => Relationship[]
+  useEntityPositions: () => Record<string, Position>
+  useLayout: () => Layout
+  useHighlightEntities: () => string[]
+  useXRayMode: () => boolean
+  useIsSidebarOpen: () => boolean
+  useCaption: () => string
+  useIsFetching: () => boolean
+  useEntityTypeFilter: () => 'all' | Entity['type']
+  useResetCam: () => boolean
+  useTargetEntity: () => string | null
+  useSearchQuery: () => string
+  useRichMediaMode: () => boolean
+  useActiveScene: () => unknown | null
+  useSelectedRelationships: () => Relationship[]
+  useKnowledgeGraphId: () => string | null
+  useProcessingMethod: () => ProcessingMethod
 }
+
+export const useEntities = () => useStore((s) => s.entities)
+export const useRelationships = () => useStore((s) => s.relationships)
+export const useEntityPositions = () => useStore((s) => s.entityPositions)
+export const useLayout = () => useStore((s) => s.layout)
+export const useHighlightEntities = () => useStore((s) => s.highlightEntities)
+export const useXRayMode = () => useStore((s) => s.xRayMode)
+export const useIsSidebarOpen = () => useStore((s) => s.isSidebarOpen)
+export const useCaption = () => useStore((s) => s.caption)
+export const useIsFetching = () => useStore((s) => s.isFetching)
+export const useEntityTypeFilter = () => useStore((s) => s.entityTypeFilter)
+export const useResetCam = () => useStore((s) => s.resetCam)
+export const useTargetEntity = () => useStore((s) => s.targetEntity)
+export const useSearchQuery = () => useStore((s) => s.searchQuery)
+export const useRichMediaMode = () => useStore((s) => s.richMediaMode)
+export const useActiveScene = () => useStore((s) => s.activeScene)
+export const useSelectedRelationships = () => useStore((s) => s.selectedRelationships)
+export const useKnowledgeGraphId = () => useStore((s) => s.knowledgeGraphId)
+export const useProcessingMethod = () => useStore((s) => s.processingMethod)
 
 export default useStore
 


### PR DESCRIPTION
## Summary
- add architecture and checklist documentation for the HKG defaults & LLM navigator plan
- implement a persisted settings store, connection drawer UI, typed HKG/JSON loaders, and the Ollama/OpenRouter LLM client
- update data/AI UI components to consume the new typed selectors and document 192.168.0.71 defaults

## Testing
- npm run lint *(fails: existing Scene3D/layout lint violations and react-hooks warnings to address separately)*

------
https://chatgpt.com/codex/tasks/task_e_68d6910b9720832395de078ce611040d