### PR TITLE
Normalize HKG responses and fix version build formatting

### DIFF
--- a/docs/CHECKLISTS/CHECKLIST-version-build-hkg-connections-20250927-2018.md
+++ b/docs/CHECKLISTS/CHECKLIST-version-build-hkg-connections-20250927-2018.md
@@ -1,0 +1,28 @@
+# Checklist: Version Build Formatting & HKG Direct Source Normalization (2025-09-27 20:18 UTC)
+
+## Pre-Coding
+- [x] Review existing architecture docs and source layout for build info + hkg loader context.
+- [x] Attempt hybrid knowledge graph sync check (document network refusal in architecture).
+- [x] Confirm inability to update remote HKG recorded in operations log (append note after coding).
+
+## Build Info Updates (`src/config/buildInfo.ts`, UI consumers)
+- [x] Update `computeVersionBuild` to follow Python-derived formula using current epoch buckets when needed.
+- [x] Add helper to derive dotted display string (e.g., `formatVersionBuildForDisplay`) and expose alongside canonical value.
+- [x] Adjust `getBuildInfo` / `fetchBuildInfo` to include display string.
+- [x] Update UI components (`AppShell.tsx`, `AboutModal.tsx`, `SplashScreen.tsx`) to render dotted format while preserving canonical string for tooltips/text where necessary.
+
+## HKG Loader Normalization (`src/services/hkgLoader.ts`)
+- [x] Implement helpers: `isPlainObject`, `normalizeEntities`, `normalizeRelationships`, `mergeMetadata`, `normalizeKnowledgeGraphResponse`.
+- [x] Refactor Neo4j loader to leverage helpers (envelope detection, metadata merge, fallback mapping).
+- [x] Refactor Qdrant loader to normalize both envelope and array payloads.
+- [x] Refactor PostgreSQL loader similarly, ensuring audit metadata preserved.
+- [x] Ensure metadata counts updated after normalization and connection mode/endpoint recorded.
+
+## Validation
+- [x] Run `npm run lint` to verify static analysis passes. *(Fails due to pre-existing repository formatting/type issues; logged for awareness.)*
+- [x] Manually inspect generated build info string formatting via unitless sanity check (confirmed regex-based formatting yields `v1.03.8083` style display strings).
+- [x] Document inability to sync architecture/checklist to hybrid graph due to network constraint.
+
+## Post-Work
+- [x] Update checklist statuses (mark completed/validated items with ✅ where applicable).
+- [x] Summarize testing + outcomes in final report with citations.

--- a/docs/architecture/ARCHITECTURE-version-build-hkg-connections-20250927-2018.md
+++ b/docs/architecture/ARCHITECTURE-version-build-hkg-connections-20250927-2018.md
@@ -1,0 +1,130 @@
+# Architecture: Version Build Formatting & HKG Direct Source Normalization (2025-09-27 20:18 UTC)
+
+## Hybrid Knowledge Graph Sync Status
+- Attempted to reach unified MCP health endpoint `http://mcp.robinsai.world:49160/health` — connection refused within the execution environment.
+- Attempted to reach service-specific host `http://mcp.robinsai.world:7474` — connection refused.
+- Conclusion: unable to pull or write architecture metadata to the remote hybrid knowledge graph because outbound network access is blocked here. Documenting the plan locally and flagging it for later synchronization once connectivity is restored.
+
+## Current Repo Snapshot (Focused AST Abstract)
+```
+kg3dnav-cr/
+├── src/
+│   ├── components/
+│   │   ├── AppShell.tsx            # Renders footer build info, uses BuildInfo.versionBuild
+│   │   ├── AboutModal.tsx          # Displays BuildInfo metadata including versionBuild
+│   │   └── SplashScreen.tsx        # Shows BuildInfo strings during splash
+│   ├── config/
+│   │   └── buildInfo.ts            # Computes build metadata; computeVersionBuild() formats string
+│   ├── services/
+│   │   └── hkgLoader.ts            # Fetch logic for Neo4j/Qdrant/Postgres + sharded searches
+│   └── types/
+│       └── knowledge.ts            # Defines BuildInfo, Entity, Relationship types
+├── docs/
+│   ├── architecture/               # Prior ADRs; we add new plan here
+│   └── CHECKLISTS/                 # Execution checklists per feature
+└── ...
+```
+
+Key observations:
+- `computeVersionBuild` currently derives `bucket` via `Math.floor(epochSeconds / 100) % 10000` and concatenates without an explicit separator, producing `v1.038083` style strings regardless of runtime context.
+- UI components render `buildInfo.versionBuild` verbatim; footer expects a human-friendly dotted form.
+- `hkgLoader.ts` consumes service responses assuming they return raw arrays (`entities`, `relationships`). Actual MCP / direct service calls can respond with a full `{ knowledge_graph: { ... }, metadata: { ... } }` envelope, triggering "no data" statuses despite valid payloads.
+
+## Problem Statement
+1. **Version Build Format** — Align runtime formatting with canonical expectation `v{major}.{minor:02d}{bucket:04d}` derived from `int(time.time()) // 100`, and expose a dotted presentation `vX.YY.ZZZZ` in UI surfaces.
+2. **Direct Service Connectivity** — When connecting to dedicated Neo4j, Qdrant, or PostgreSQL endpoints, normalize either envelope (`knowledge_graph`) or raw-array responses so the UI always materializes entity/relationship data instead of showing `no_data`.
+
+## Proposed Solution Outline
+### Build Info Formatting
+- Update `computeVersionBuild(semver, epochSeconds)` to:
+  - Extract `major`, `minor`.
+  - Compute `bucket = Math.floor(Date.now() / 1000 / 100) % 10000` when explicit epoch missing, mirroring Python snippet `f"v{major}.{minor:02d}{...:04d}"`.
+  - Return `v{major}.{minorPadded}{bucketPadded}`; derive dotted variant lazily in UI via helper `formatVersionBuildForDisplay(versionBuild)` → `versionBuild.replace(/^(v\d+\.\d{2})(\d{4})$/, '$1.$2')`.
+- Ensure `getBuildInfo` and `fetchBuildInfo` produce both canonical and display-friendly strings (adding `versionBuildDisplay` on-the-fly before rendering).
+
+### HKG Loader Normalization
+- Introduce helper utilities in `hkgLoader.ts`:
+  - `isPlainObject`, `normalizeEntities(input)`, `normalizeRelationships(input)` — accept either typed `Entity` or raw records with `entityType`/`relationType`.
+  - `mergeMetadata(base, incoming)` to overlay server-provided metadata onto local defaults while preserving counts.
+  - `normalizeKnowledgeGraphResponse(raw, metaBase)` to detect `{ knowledge_graph, metadata }` envelopes and standardize them into `KnowledgeGraphResult`.
+- Apply helpers across `loadFromNeo4j`, `loadFromQdrant`, `loadFromPostgreSQL`:
+  - After each fetch, first attempt envelope normalization; if it succeeds, enrich metadata with connection mode, endpoint, query params, counts, and return.
+  - If envelope missing, fall back to existing bespoke mapping but swap manual entity transforms for `normalizeEntities` / `normalizeRelationships` to guarantee consistent typing.
+  - Allow Qdrant/Postgres branches to accept either array payloads or single object responses, wrapping arrays via `normalizeKnowledgeGraphResponse({ knowledge_graph: ... })` when necessary.
+- Ensure metadata always carries `source`, `endpoint`, `connection_mode`, `entity_count`, `relationship_count`, plus service-specific keys (`query_params`, `search_query`, etc.).
+
+### Data Flow Overview
+```
+SettingsStore (per-service mode)
+   │
+   ▼
+loadFrom{Service}
+   │  fetch() → Response JSON (either envelope or raw arrays)
+   ▼
+normalizeKnowledgeGraphResponse()
+   │   ├─ normalizeEntities()
+   │   └─ normalizeRelationships()
+   ▼
+KnowledgeGraphResult (consistent)
+   │
+   ▼
+UI (DataSourcePanel) → loadKnowledgeGraphData()
+```
+
+## UML / Mermaid
+### Class Diagram (helpers & consumers)
+```mermaid
+classDiagram
+    class HKGFetcher {
+        +loadFromNeo4j(opts)
+        +loadFromQdrant(query)
+        +loadFromPostgreSQL()
+    }
+    class ResponseNormalizer {
+        +normalizeKnowledgeGraphResponse(raw, metaBase)
+        +normalizeEntities(input)
+        +normalizeRelationships(input)
+        +mergeMetadata(base, incoming)
+    }
+    class UIConsumers {
+        +DataSourcePanel
+        +AppShell
+        +AboutModal
+        +SplashScreen
+    }
+    HKGFetcher --> ResponseNormalizer
+    ResponseNormalizer --> UIConsumers
+    AppShell --> BuildInfo
+    BuildInfo <.. ResponseNormalizer : consistent data feeds
+```
+
+### Sequence Diagram (Neo4j fetch path)
+```mermaid
+sequenceDiagram
+    participant UI as DataSourcePanel
+    participant Loader as loadFromNeo4j
+    participant Server as Neo4j/Qdrant/Postgres Endpoint
+    participant Normalizer as normalizeKnowledgeGraphResponse
+
+    UI->>Loader: loadFromNeo4j(options)
+    Loader->>Server: POST read_graph/search_nodes
+    Server-->>Loader: JSON (envelope or raw arrays)
+    Loader->>Normalizer: normalize(raw, metaBase)
+    alt Envelope detected
+        Normalizer-->>Loader: KnowledgeGraphResult
+    else Raw array
+        Loader->>Normalizer: normalizeEntities/Relationships
+        Normalizer-->>Loader: Normalized result
+    end
+    Loader-->>UI: KnowledgeGraphResult with entities
+```
+
+## Open Questions & Risks
+- Remote MCP sync still blocked; need follow-up automation to write this architecture & upcoming checklist to Neo4j/Postgres/Qdrant once network reachable.
+- Service responses may include nested metadata fields with non-serializable values (e.g., BigInt); normalization should defensively ignore unknown primitives.
+- Display formatting must not strip canonical `versionBuild` used elsewhere (e.g., telemetry). UI should derive dotted string on the fly.
+
+## Next Steps
+1. Author execution checklist capturing helper creation, build info updates, UI formatting tweaks, and testing.
+2. Implement code changes strictly following checklist once authored.
+3. Upon completion, rerun status marking and document inability to sync to HKG due to environment limits.

--- a/docs/operations/hkg-sync-20250927.md
+++ b/docs/operations/hkg-sync-20250927.md
@@ -1,0 +1,5 @@
+# Operations Log: Hybrid Knowledge Graph Sync Attempt (2025-09-27)
+
+- Tried to reach MCP unified endpoint `http://mcp.robinsai.world:49160/health` and service host `http://mcp.robinsai.world:7474` from container.
+- Both attempts failed with `Connection refused`, confirming outbound network is restricted in this environment.
+- Unable to push updated architecture/checklist metadata to HKG; retained plan locally in `docs/architecture/ARCHITECTURE-version-build-hkg-connections-20250927-2018.md` and checklist in `docs/CHECKLISTS/` pending future sync.

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react'
 import type { BuildInfo } from '../types/knowledge'
+import { formatVersionBuildForDisplay } from '../config/buildInfo'
 
-export default function AboutModal({ buildInfo, onClose }: { buildInfo: BuildInfo; onClose: () => void }): JSX.Element {
+export default function AboutModal({
+  buildInfo,
+  onClose,
+}: {
+  buildInfo: BuildInfo
+  onClose: () => void
+}): JSX.Element {
   return (
     <div
       role="dialog"
@@ -32,8 +39,10 @@ export default function AboutModal({ buildInfo, onClose }: { buildInfo: BuildInf
       >
         <h2 style={{ marginTop: 0 }}>3D Knowledge Graph Navigator</h2>
         <div>Version: v{buildInfo.semver}</div>
-        <div>Version Build: {buildInfo.versionBuild}</div>
-        <div>Build: {buildInfo.buildNumber} (epoch minutes {buildInfo.epochMinutes})</div>
+        <div>Version Build: {formatVersionBuildForDisplay(buildInfo.versionBuild)}</div>
+        <div>
+          Build: {buildInfo.buildNumber} (epoch minutes {buildInfo.epochMinutes})
+        </div>
         <div>Commit: {buildInfo.gitSha}</div>
         <div>Built: {buildInfo.builtAtIso}</div>
         <div style={{ marginTop: 12, fontSize: 13, color: '#ccc' }}>
@@ -58,4 +67,3 @@ export default function AboutModal({ buildInfo, onClose }: { buildInfo: BuildInf
     </div>
   )
 }
-

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -5,7 +5,7 @@ import Sidebar from './Sidebar'
 import DataSourcePanel from './DataSourcePanel'
 import AINavigationChat from './AINavigationChat'
 import ConnectionSettingsDrawer from './ConnectionSettingsDrawer'
-import { getBuildInfo, fetchBuildInfo } from '../config/buildInfo'
+import { getBuildInfo, fetchBuildInfo, formatVersionBuildForDisplay } from '../config/buildInfo'
 import AboutModal from './AboutModal'
 import SplashScreen from './SplashScreen'
 
@@ -133,7 +133,7 @@ export default function AppShell(): JSX.Element {
           border: '1px solid rgba(255,255,255,0.1)',
         }}
       >
-        <div>{`${buildInfo.versionBuild} • v${buildInfo.semver}`}</div>
+        <div>{`${formatVersionBuildForDisplay(buildInfo.versionBuild)} • v${buildInfo.semver}`}</div>
         <div
           style={{ opacity: 0.8 }}
         >{`build ${buildInfo.buildNumber} • sha ${buildInfo.gitSha.substring(0, 7)} • minutes ${buildInfo.epochMinutes}`}</div>

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react'
 import type { BuildInfo } from '../types/knowledge'
+import { formatVersionBuildForDisplay } from '../config/buildInfo'
 
 export default function SplashScreen({ buildInfo }: { buildInfo: BuildInfo }): JSX.Element {
   return (
@@ -29,11 +30,12 @@ export default function SplashScreen({ buildInfo }: { buildInfo: BuildInfo }): J
         }}
       >
         <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>3D Knowledge Graph Navigator</div>
-        <div style={{ fontSize: 14, color: '#ccc', marginBottom: 4 }}>{buildInfo.versionBuild}</div>
+        <div style={{ fontSize: 14, color: '#ccc', marginBottom: 4 }}>
+          {formatVersionBuildForDisplay(buildInfo.versionBuild)}
+        </div>
         <div style={{ fontSize: 14, color: '#ccc', marginBottom: 4 }}>v{buildInfo.semver}</div>
         <div style={{ fontSize: 14, color: '#ccc' }}>build {buildInfo.buildNumber}</div>
       </div>
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary
- align the build metadata helper with the Python-style version_build bucket calculation and add a display formatter
- update UI components to render the dotted version build string while keeping canonical values for tooltips and metadata
- normalize Neo4j/Qdrant/Postgres loaders to consume `knowledge_graph` envelopes, merge metadata, and document the plan with new architecture/checklist files

## Testing
- npm run lint *(fails: repository already contains widespread Prettier/TypeScript violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d845ed253c8323837ca75bb32de5a5