### PR TITLE
Add initial load overlay to communicate startup state

### DIFF
--- a/docs/ARCHITECTURE/20250929T040348Z-initial-load-overlay.md
+++ b/docs/ARCHITECTURE/20250929T040348Z-initial-load-overlay.md
@@ -1,0 +1,159 @@
+# Architecture — Initial Load Experience Overlay (2025-09-29T04:03:48Z)
+
+## Context & Scope
+- Repository: `kg3dnav-cr`
+- Goal: address "blank background screen on load init" by introducing an initial load overlay that communicates application state while knowledge graph data is fetched.
+- Constraints: unable to interface with external hybrid knowledge graph infrastructure from this environment; planned architecture reflects repository reality only.
+
+## High-Level System Overview
+```
+kg3dnav-cr
+├── src
+│   ├── main.tsx — React entry point bootstrapping <AppShell/> inside an ErrorBoundary
+│   ├── components
+│   │   ├── AppShell.tsx — orchestrates layout (Canvas3D, Sidebar, panels, drawers, splash/about modals)
+│   │   ├── Canvas3D.tsx — react-three-fiber <Canvas> hosting <Scene3D/>
+│   │   ├── Scene3D.tsx — renders lights, controls, graph nodes/relationships, fallback mesh when no data
+│   │   ├── DataSourcePanel.tsx — manages data source selection & auto-load flow
+│   │   ├── Sidebar.tsx — entity list & interactions (conditional on store.isSidebarOpen)
+│   │   └── ... (AINavigationChat, Connection settings/debug UIs, modals)
+│   ├── state
+│   │   ├── store.ts — zustand store (entities, relationships, layout, UI flags)
+│   │   └── actions.ts — mutators (loadKnowledgeGraphData, layout toggles, search, etc.)
+│   ├── services — integration with HKG backends (Neo4j/Qdrant/Postgres), layout engine, file loaders
+│   ├── types — TypeScript definitions (Entity, Relationship, BuildInfo, etc.)
+│   └── config — build metadata utilities
+├── index.html — injects global styles, mounts #root
+└── src-tauri — desktop wrapper (not directly touched here)
+```
+
+## Existing Rendering Flow (Abstract AST Perspective)
+```
+ReactDOM.createRoot(#root)
+└── <StrictMode>
+    └── <ErrorBoundary>
+        └── <AppShell>
+            ├── <Canvas3D>
+            │   └── <Canvas style.background gradient>
+            │       └── <Scene3D>
+            │           ├── <lights>
+            │           ├── <TrackballControls>
+            │           ├── Conditional fallback geometry when entities.length === 0
+            │           └── Map entities/relationships → <KnowledgeNode/> & <RelationshipLine/>
+            ├── <Sidebar/> (rendered only when store.isSidebarOpen)
+            ├── <DataSourcePanel/> (always mounted; owns auto-load timers & status UI)
+            ├── <AINavigationChat/>, <ConnectionDebugSidebar/>, <ConnectionSettingsDrawer/>
+            ├── Header buttons (About, Settings, Logs)
+            ├── Version badge (bottom-right)
+            ├── Conditional overlays
+            │   ├── {showSplash && <SplashScreen/>}
+            │   └── {aboutOpen && <AboutModal/>}
+            └── (No current overlay specifically for "no data yet" state once splash hides)
+```
+
+## Problem Characterization
+- After splash screen auto-dismisses (~1.2s), there is a visual gap before data loads or user opens panels.
+- During this gap the viewport shows only the gradient background (Canvas with no graph + hidden sidebar), leading to "blank screen" perception.
+- Need a persistent, informative overlay for "no data loaded" & "currently loading" states using existing zustand flags (`entities`, `isFetching`, `caption`).
+
+## Proposed Solution Architecture
+### Components & State
+1. **`InitialLoadOverlay.tsx` (new)**
+   - Props: none; consumes zustand selectors (`useEntities`, `useIsFetching`, `useCaption`).
+   - Derived flags:
+     - `hasEntities = entities.length > 0`
+     - `isBusy = useIsFetching()`
+     - `message = caption || defaultText`
+   - Render logic:
+     - When `hasEntities` → render `null` (overlay hidden).
+     - Else render a fixed-position overlay card (semi-transparent dark background) with:
+       - App title & short guidance (e.g., "Loading knowledge graph…" or "Use data sources panel to connect").
+       - Animated spinner indicator when `isBusy`.
+       - Additional context lines (wired to `message`).
+   - Accessibility: include `role="status"` and `aria-live="polite"` for screen readers.
+   - Styling: consistent with existing overlays (rounded corners, blurred background). Use inline styles like other components.
+
+2. **`AppShell` integration**
+   - Import `InitialLoadOverlay`.
+   - Render overlay near end of `main` but above splash/about order so z-index layering remains: ensure overlay sits below splash (zIndex < 1500) but above Canvas (zIndex ~?). Example `zIndex: 900`.
+   - The overlay should stay visible even after splash disappears until data arrives.
+
+3. **Optional caption wiring**
+   - `loadKnowledgeGraphData` already sets `caption`. No changes required, but ensure fallback message covers zero caption scenario.
+
+### Interaction Sequence
+```
+AppShell mount
+├─ showSplash=true (0-1.2s) → SplashScreen visible (zIndex 1500)
+├─ InitialLoadOverlay sees hasEntities=false → renders guidance card (zIndex 900)
+├─ DataSourcePanel auto triggers load → store.isFetching toggles true → overlay shows spinner & "Loading..."
+└─ Once data arrives (entities.length > 0) → overlay unmounts automatically, revealing graph + UI
+```
+
+## UML / Mermaid Diagrams
+### Component Collaboration (Mermaid Class Diagram)
+```mermaid
+classDiagram
+    class AppShell {
+      -buildInfo: BuildInfo
+      -showSplash: boolean
+      -settingsOpen: boolean
+      -aboutOpen: boolean
+      -useLogPanelState()
+      +render(): JSX.Element
+    }
+    class InitialLoadOverlay {
+      -entities: Entity[]
+      -isFetching: boolean
+      -caption: string
+      +render(): JSX.Element
+    }
+    class DataSourcePanel {
+      -load()
+      -loadKnowledgeGraphData()
+    }
+    class Store {
+      +entities: Entity[]
+      +isFetching: boolean
+      +caption: string
+    }
+    AppShell --> Canvas3D
+    AppShell --> Sidebar
+    AppShell --> DataSourcePanel
+    AppShell --> InitialLoadOverlay
+    InitialLoadOverlay --> Store
+    DataSourcePanel --> Store
+```
+
+### Initial Load Mindmap (Mermaid Mindmap)
+```mermaid
+mindmap
+  root((Initial Load UX))
+    Splash Screen
+      duration 1.2s
+      zIndex 1500
+    Initial Load Overlay
+      listens
+        entities.length
+        isFetching
+        caption
+      states
+        Idle Guidance
+        Loading Spinner
+        Hidden when data ready
+    Data Sources
+      auto trigger @0.8s
+      status updates
+      update store via loadKnowledgeGraphData
+    Canvas3D
+      shows fallback mesh when no entities
+```
+
+## Data Persistence Alignment
+- No schema changes; overlay consumes existing store fields.
+- No additional dependencies or side effects.
+
+## Testing Strategy
+- Manual: run `npm run dev`, observe overlay presence pre-data, verify disappearance post-load.
+- Automated: rely on TypeScript compile (`npm run build`) ensuring new component types valid.
+

--- a/docs/CHECKLISTS/20250929T040348Z-initial-load-overlay.md
+++ b/docs/CHECKLISTS/20250929T040348Z-initial-load-overlay.md
@@ -1,0 +1,38 @@
+# Checklist — Initial Load Experience Overlay (2025-09-29T04:03:48Z)
+
+## Pre-Coding
+- [x] Architecture document created (docs/ARCHITECTURE/20250929T040348Z-initial-load-overlay.md).
+- [x] Confirm no additional AGENTS.md constraints (none found).
+
+## Implementation Steps
+1. [x] **Create component** `src/components/InitialLoadOverlay.tsx`
+   - [x] Import React hooks (`useMemo`) if needed and zustand selectors: `useEntities`, `useIsFetching`, `useCaption` from `../state/store`.
+   - [x] Compute `hasEntities`, `isBusy`, `message` (fallback message string when caption empty).
+   - [x] Render `null` when `hasEntities` true.
+   - [x] Otherwise render `div` overlay with inline styles:
+     - [x] Position: `absolute`, `inset: 0`, display flex center, `zIndex: 900`, pointer events none for wrapper; inner card pointer events auto.
+     - [x] Inner card: dark translucent background, border, blur (`backdropFilter`), padding, max width 420, text align center.
+     - [x] Include heading (app name), subtext instructions, dynamic `message`, spinner indicator (CSS animation using inline keyframes or simple rotating border via inline `@keyframes` + style). Use `<div role="status" aria-live="polite">` semantics.
+   - [x] Ensure TypeScript types correct.
+
+2. [x] **Integrate overlay** in `src/components/AppShell.tsx`
+   - [x] Import `InitialLoadOverlay` at top.
+   - [x] Render `<InitialLoadOverlay />` inside `<main>`, after existing panels but before splash/about modals (to keep z-index layering) or adjust order according to architecture doc.
+
+3. [x] **Optional store tweak** (only if needed) — ensure `useCaption` selector exported; confirm existing export, otherwise add in `src/state/store.ts`.
+   - [x] If export missing, add `export const useCaption = () => useStore((s) => s.caption)`.
+
+4. [x] **Styling verification**
+   - [x] Ensure overlay pointer-events do not block interactions once hidden (conditionally render `null`).
+   - [x] Spinner accessible fallback (aria-hidden, adds `Loading…` text for screen readers).
+
+## Testing & Verification
+- [x] Run `npm run build` to ensure TypeScript + bundler succeed. *(Fails due to existing Vite externalization error for `@bufbuild/connect-node` → `util.promisify`.)*
+- [x] (Optional) `npm run lint` if available (check package.json scripts) — run if script exists. *(Fails with pre-existing lint violations across repository unrelated to current changes.)*
+- [ ] Manual verification recommended (npm run dev) though not executed here.
+
+## Post-Coding
+- [ ] Update checklist statuses accordingly (mark ✅ after tests pass).
+- [x] Commit changes with descriptive message.
+- [x] Generate PR via `make_pr` with summary referencing overlay enhancement.
+

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -9,6 +9,7 @@ import ConnectionDebugSidebar from './ConnectionDebugSidebar'
 import { getBuildInfo, fetchBuildInfo, formatVersionBuildForDisplay } from '../config/buildInfo'
 import AboutModal from './AboutModal'
 import SplashScreen from './SplashScreen'
+import InitialLoadOverlay from './InitialLoadOverlay'
 import { useLogPanelState } from '../state/logStore'
 
 export default function AppShell(): JSX.Element {
@@ -158,6 +159,8 @@ export default function AppShell(): JSX.Element {
       >
         <div>{`${formatVersionBuildForDisplay(buildInfo.versionBuild)} • v${buildInfo.semver}`}</div>
       </div>
+
+      <InitialLoadOverlay />
 
       {showSplash && <SplashScreen buildInfo={buildInfo} />}
       {aboutOpen && <AboutModal buildInfo={buildInfo} onClose={() => setAboutOpen(false)} />}

--- a/src/components/InitialLoadOverlay.tsx
+++ b/src/components/InitialLoadOverlay.tsx
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+import React, { useMemo } from 'react'
+import { useCaption, useEntities, useIsFetching } from '../state/store'
+
+export default function InitialLoadOverlay(): JSX.Element | null {
+  const entities = useEntities()
+  const isFetching = useIsFetching()
+  const caption = useCaption()
+
+  const hasEntities = entities.length > 0
+  const message = useMemo(() => {
+    const trimmed = caption?.trim()
+    if (trimmed) return trimmed
+    return isFetching
+      ? 'Loading knowledge graph data...'
+      : 'Connect to a data source to begin exploring the graph.'
+  }, [caption, isFetching])
+
+  if (hasEntities) return null
+
+  return (
+    <>
+      <style>
+        {`
+          @keyframes initial-load-spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+          }
+        `}
+      </style>
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+          zIndex: 900,
+        }}
+      >
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            pointerEvents: 'auto',
+            background: 'rgba(0,0,0,0.82)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: 16,
+            padding: '28px 32px',
+            maxWidth: 420,
+            textAlign: 'center',
+            color: 'rgba(255,255,255,0.92)',
+            fontFamily: 'Inter, sans-serif',
+            backdropFilter: 'blur(8px)',
+            boxShadow: '0 20px 60px rgba(0,0,0,0.45)',
+          }}
+        >
+          <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 12 }}>3D Knowledge Graph Navigator</div>
+          <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.65)', marginBottom: 18 }}>
+            Initializing your exploration workspace…
+          </div>
+          {isFetching && (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+              <div
+                aria-hidden="true"
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: '50%',
+                  border: '3px solid rgba(255,255,255,0.15)',
+                  borderTopColor: '#4ECDC4',
+                  animation: 'initial-load-spin 1s linear infinite',
+                }}
+              />
+              <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.7)' }}>Loading…</div>
+            </div>
+          )}
+          <div style={{ fontSize: 14, lineHeight: 1.5, marginBottom: isFetching ? 4 : 12 }}>{message}</div>
+          {!isFetching && !caption?.trim() && (
+            <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.55)' }}>
+              Use the data sources panel in the upper right corner to connect.
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- capture planning for the initial load experience in new architecture and checklist documents
- add an InitialLoadOverlay component that surfaces startup guidance and loading status while no entities are present
- mount the overlay in AppShell so the app no longer shows a blank background during initial data loading

## Testing
- npm run build *(fails: Vite build aborts because @bufbuild/connect-node depends on Node's util.promisify which is externalized for the browser)*
- npm run lint *(fails: existing repository-wide lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68da03ea18448323b7ec39e46305f828